### PR TITLE
Refactor: System Call and L1 Message Handling in REVM

### DIFF
--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -95,11 +95,8 @@ where
         &self,
         evm: &mut Self::Evm,
     ) -> Result<(), Self::Error> {
-        let (_, tx, cfg, journal, _, _) = evm.ctx().all_mut();
-        // System transaction - skip all validation
-        if cfg.disable_fee_charge {
-            return Ok(());
-        }
+        let (_, tx, _, journal, _, _) = evm.ctx().all_mut();
+
         // L1 message - skip fee validation
         if tx.is_l1_msg() {
             // Load caller's account
@@ -128,10 +125,10 @@ where
         evm: &mut Self::Evm,
         exec_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
     ) -> Result<(), Self::Error> {
-        let (_, tx, cfg, _, _, _) = evm.ctx().all_mut();
+        let (_, tx, _, _, _, _) = evm.ctx().all_mut();
 
         // For L1 message transactions & system transactions, no reimbursement is needed
-        if tx.is_l1_msg() || cfg.disable_fee_charge {
+        if tx.is_l1_msg() {
             return Ok(());
         }
 
@@ -154,10 +151,7 @@ where
         exec_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
     ) -> Result<(), Self::Error> {
         let (block, tx, cfg, journal, _, _) = evm.ctx().all_mut();
-        // System transaction - skip all reward
-        if cfg.disable_fee_charge {
-            return Ok(());
-        }
+
         // L1 message transactions skip all reward.
         // MorphTransaction rewards are already applied when gasFee is deducted.
         if tx.is_l1_msg() || tx.is_morph_tx() {
@@ -200,8 +194,8 @@ where
 
     #[inline]
     fn validate_env(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
-        // For L1 message transactions & System transaction, skip certain validations
-        if evm.ctx_ref().tx().is_l1_msg() || evm.ctx_ref().cfg().disable_fee_charge {
+        // For L1 message transactions
+        if evm.ctx_ref().tx().is_l1_msg() {
             // L1 messages have zero gas price, so skip gas price validation
             return Ok(());
         }
@@ -484,7 +478,6 @@ where
             let mut state = evm.finalize();
             state.iter_mut().for_each(|(_, acc)| {
                 acc.mark_cold();
-                acc.unmark_touch();
                 acc.storage
                     .iter_mut()
                     .for_each(|(_, slot)| slot.mark_cold());

--- a/crates/revm/src/token_fee.rs
+++ b/crates/revm/src/token_fee.rs
@@ -245,23 +245,6 @@ where
 {
     // Fallback: Execute EVM call to balanceOf(address)
     let calldata = build_balance_of_calldata(account);
-
-    // Create a minimal transaction environment for the call
-    // let tx = TxEnv {
-    //     caller: Address::ZERO,
-    //     gas_limit: BALANCE_OF_GAS_LIMIT,
-    //     kind: TxKind::Call(token),
-    //     value: U256::ZERO,
-    //     data: calldata,
-    //     nonce: 0,
-    //     ..Default::default()
-    // };
-
-    // // Convert to MorphTxEnv
-    // let morph_tx = crate::MorphTxEnv::new(tx);
-
-    // Execute using transact_one
-    evm.cfg.disable_fee_charge = true; // Disable fee charge for system call
     match evm.system_call_one(token, calldata) {
         Ok(result) => {
             if result.is_success() {


### PR DESCRIPTION
This pull request refactors the handling of system calls and L1 messages within the REVM for improved clarity and efficiency.

The key changes include:

- __Removal of `disable_fee_charge` flag:__ The `disable_fee_charge` flag, which was previously used to bypass fee validation and rewards for system transactions, has been removed. The logic now relies on more explicit checks, such as `tx.is_l1_msg()`, to identify L1 messages and apply the appropriate rules.

- __Improved `balanceOf` call:__ The `balanceOf` function in the `token_fee` module has been updated to use the `system_call_one` method instead of `transact_one`. This provides a more direct and efficient way to execute the system call.

- __State "cold" optimization:__ An optimization has been added to mark the state as "cold" after pre-execution state changes. This prevents warm account access in the main transaction execution, improving performance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified transaction fee handling and validation logic for improved consistency across transaction types.
  * Streamlined token-based fee mechanism for more efficient balance lookups.

* **Bug Fixes**
  * Corrected fee validation and reimbursement logic for different transaction types to ensure proper execution paths.
  * Improved state management by properly marking transaction states during execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->