### PR TITLE
fix(release): remove checklists from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,24 +167,9 @@ jobs:
           fi
 
           cat <<ENDBODY > release_notes.md
-          ## Testing Checklist (DELETE ME)
-
-          - [ ] Run on testnet for 1-3 days.
-          - [ ] Resync a node from genesis.
-          - [ ] Ensure all CI checks pass.
-
-          ## Release Checklist (DELETE ME)
-
-          - [ ] Ensure version has been bumped in \`Cargo.toml\`.
-          - [ ] Write the summary below.
-          - [ ] Ensure all binaries have been added.
-
           ## Summary
 
-          <!-- Add a summary of the release, including:
-          - Critical bug fixes
-          - New features
-          - Any breaking changes -->
+          <!-- Add a summary of the release, including critical bug fixes, new features, and breaking changes. -->
 
           ## All Changes
 


### PR DESCRIPTION
Remove testing/release checklists from the auto-generated draft release notes so releases can be published directly without manual cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal release workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->