### PR TITLE
fix(rpc): handle eth_config when no timestamp fork is active yet

### DIFF
--- a/crates/rpc/src/eth_config.rs
+++ b/crates/rpc/src/eth_config.rs
@@ -201,11 +201,14 @@ where
         fork_timestamps.dedup();
 
         let latest_ts = latest.timestamp();
+        // If no timestamp fork is active yet (e.g. we're still in the block-based fork era,
+        // like early Bernoulli/Curie blocks), use the current block's timestamp so that
+        // the fork config reflects the current chain state (pre-Morph203, useZktrie=true).
         let current_fork_timestamp = fork_timestamps
             .iter()
             .copied()
             .rfind(|&ts| ts <= latest_ts)
-            .ok_or_else(|| RethError::msg("no active timestamp fork found"))?;
+            .unwrap_or(latest_ts);
         let next_fork_timestamp = fork_timestamps.iter().copied().find(|&ts| ts > latest_ts);
 
         let current = self.build_fork_config_at(current_fork_timestamp, current_precompiles);


### PR DESCRIPTION
## Summary

- `eth_config` returned error `"no active timestamp fork found"` when the chain is at block 0 (Bernoulli/Curie block-based fork era)
- This caused morphnode to fail its startup readiness check and retry indefinitely, blocking sync from genesis
- Fixed by falling back to `latest_ts` when no timestamp fork is active, so the response correctly reflects the current chain state (`useZktrie: true`, `jadeForkTime` set, `next` pointing to Morph203)

## Root Cause

`eth_config` collects all timestamp-based fork activation timestamps and finds the latest one `<= latest block timestamp`. At genesis (block 0, timestamp ~0 or early), all timestamp forks (Morph203 @ 1747029600, Viridian, Emerald, Jade) are in the future, so `rfind` returns `None` → error.

## Test Plan

- [x] `cargo check -p morph-rpc` passes
- [x] `cargo build --release` passes
- [x] Started mainnet node from genesis: morphnode no longer loops on "Waiting for geth to be ready" and begins syncing immediately
- [x] `eth_config` response at block 0 correctly returns `useZktrie: true` and `jadeForkTime`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced fork timestamp selection to gracefully handle scenarios where no active timestamp fork exists. The system now falls back to the current block timestamp instead of failing, ensuring stable operation across all timestamp configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->