### PR TITLE
perf(txpool): reuse state provider across batch validation

### DIFF
--- a/crates/txpool/src/validator.rs
+++ b/crates/txpool/src/validator.rs
@@ -246,6 +246,22 @@ where
         origin: TransactionOrigin,
         transaction: Tx,
     ) -> TransactionValidationOutcome<Tx> {
+        self.validate_one_with_state(origin, transaction, &mut None)
+    }
+
+    /// Validates a single transaction, reusing an optional state provider.
+    ///
+    /// When `state` is `None`, a fresh provider is fetched from the database on
+    /// first use and stored back into `state` for reuse by subsequent calls.
+    /// This avoids creating a new [`StateProvider`] for every transaction in a
+    /// batch, which is the main source of txpool validation slowdown as the
+    /// state trie grows.
+    pub fn validate_one_with_state(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Tx,
+        state: &mut Option<Box<dyn reth_storage_api::AccountInfoReader + Send>>,
+    ) -> TransactionValidationOutcome<Tx> {
         // Reject EIP-4844 blob transactions - not supported on L2
         if transaction.is_eip4844() {
             return TransactionValidationOutcome::Invalid(
@@ -290,7 +306,9 @@ where
             );
         }
 
-        let outcome = self.inner.validate_one(origin, transaction);
+        let outcome = self
+            .inner
+            .validate_one_with_state(origin, transaction, state);
         if outcome.is_invalid() || outcome.is_error() {
             tracing::trace!(target: "morph::txpool", ?outcome, "tx pool validation failed");
             return outcome;
@@ -435,7 +453,7 @@ where
         Ok(result)
     }
 
-    /// Validates all given transactions.
+    /// Validates all given transactions, reusing a single state provider across the batch.
     ///
     /// Returns all outcomes for the given transactions in the same order.
     ///
@@ -444,9 +462,10 @@ where
         &self,
         transactions: Vec<(TransactionOrigin, Tx)>,
     ) -> Vec<TransactionValidationOutcome<Tx>> {
+        let mut state = None;
         transactions
             .into_iter()
-            .map(|(origin, tx)| self.validate_one(origin, tx))
+            .map(|(origin, tx)| self.validate_one_with_state(origin, tx, &mut state))
             .collect()
     }
 }


### PR DESCRIPTION
## Summary

- Reuse a single `StateProvider` across all transactions in `validate_all()`, instead of creating a new one per-tx
- Leverages the existing `validate_one_with_state()` API from reth's `EthTransactionValidator`
- As the state trie grows, opening a fresh provider per-tx becomes the dominant cost in txpool validation — this eliminates that overhead

## Changes

Only `crates/txpool/src/validator.rs`:
- Added `validate_one_with_state()` wrapper that accepts `&mut Option<Box<dyn AccountInfoReader + Send>>`
- Modified `validate_all()` to lazily initialize and reuse the state provider across the batch
- Original `validate_one()` delegates to the new method with `&mut None` (no behavior change for single-tx validation)

## Test plan

- [ ] Existing txpool unit tests pass
- [ ] CI green
- [ ] No behavior change — purely a performance optimization (same validation logic, same state snapshot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized transaction batch validation with enhanced state caching, reducing redundant account lookups and improving validation throughput when processing multiple transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->