### PR TITLE
fix(evm): restore tx_gas_limit_cap override to disable EIP-7825 on Morph

### DIFF
--- a/crates/evm/src/config.rs
+++ b/crates/evm/src/config.rs
@@ -37,6 +37,11 @@ impl ConfigureEvm for MorphEvmConfig {
             .with_chain_id(self.chain_spec().chain().id())
             .with_spec(spec);
         cfg_env.disable_eip7623 = true;
+        // Morph does not enforce EIP-7825 transaction gas limit cap. Historical mainnet
+        // transactions (e.g. block 20459477, gas_limit=21,165,068) exceed the EIP-7825
+        // cap of 2^24 (16,777,216). Cap at block gas limit instead so all valid
+        // transactions can execute regardless of which SpecId is active.
+        cfg_env.tx_gas_limit_cap = Some(header.gas_limit());
 
         let fee_recipient = self
             .chain_spec()
@@ -82,6 +87,8 @@ impl ConfigureEvm for MorphEvmConfig {
             .with_chain_id(self.chain_spec().chain().id())
             .with_spec(spec);
         cfg_env.disable_eip7623 = true;
+        // Morph does not enforce EIP-7825 transaction gas limit cap — see evm_env() above.
+        cfg_env.tx_gas_limit_cap = Some(attributes.gas_limit);
 
         let fee_recipient = self
             .chain_spec()


### PR DESCRIPTION
## Summary

- Restores `cfg_env.tx_gas_limit_cap = Some(header.gas_limit())` in both `evm_env()` and `next_evm_env()`, which was incorrectly removed in #79.
- Morph is an L2 and does not enforce EIP-7825. Without this override, Emerald-era (OSAKA spec) transactions with `gas_limit > 2^24` get silently truncated by revm, causing gas_used mismatch and sync stall.
- Specifically, mainnet block **20459477** contains tx `0x5769b5...298f636` with `gas_limit=21,165,068 > 16,777,216 (EIP-7825 cap)`.

## Root Cause

Commit 45e401e assumed the only mainnet tx exceeding the EIP-7825 cap was in block 16102224 (Morph203/CANCUN era, where no cap applies). It missed block 20459477 which is in the **Emerald era (OSAKA spec)** where revm enforces EIP-7825 by default.

## Test plan

- [ ] Verify morph-reth can sync past block 20459477 on mainnet
- [ ] `cargo check -p morph-evm` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction gas limit enforcement to properly align with block gas limits. Transaction gas limits are now correctly capped based on the current block's gas limit and the next block's anticipated gas limit, ensuring consistent and accurate validation while preventing transactions from exceeding system-designated limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->