### PR TITLE
fix(build): use git CLI for fetching cargo git dependencies on EC2

### DIFF
--- a/MakefileEc2.mk
+++ b/MakefileEc2.mk
@@ -9,7 +9,7 @@ PROFILE          ?= release
 
 define cargo_build_and_upload
 	if [ ! -d $(DIST_DIR) ]; then mkdir -p $(DIST_DIR); fi
-	cargo build --bin $(BINARY) --profile "$(PROFILE)" --target-dir "$(CARGO_TARGET_DIR)"
+	CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build --bin $(BINARY) --profile "$(PROFILE)" --target-dir "$(CARGO_TARGET_DIR)"
 	cp "$(CARGO_TARGET_DIR)/$(PROFILE)/$(BINARY)" "$(DIST_DIR)/"
 	tar -czvf $(TARBALL) $(DIST_DIR)
 	aws s3 cp $(TARBALL) $(1)


### PR DESCRIPTION
## Summary

- Add `CARGO_NET_GIT_FETCH_WITH_CLI=true` to `MakefileEc2.mk` cargo build command
- Fixes EC2 build server compilation failure where Cargo's built-in libgit2 cannot authenticate to private git repos (e.g., `morph-l2/reth`)
- System `git` CLI uses the server's configured credential helper, which works correctly

## Test plan

- [ ] Trigger a QA net build (`build-bk-test-morph-test-qanet-to-morph-reth-qanet`) and verify `cargo build` no longer fails on git fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process configuration to enhance Git handling during continuous integration builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->