### PR TITLE
fix(engine-api): add engine_appendBatchSignature RPC for sync nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Morph provides a custom L2 Engine API (different from the standard Ethereum Engi
 | `engine_newL2Block` | Import a new L2 block via `newPayload` + `forkchoiceUpdated` and advance the canonical head |
 | `engine_newSafeL2Block` | Rebuild and import a safe L2 block from derivation inputs |
 | `engine_setBlockTags` | Update safe/finalized block tags without importing a block |
+| `engine_appendBatchSignature` | Accept a BLS batch signature from the consensus layer (no-op for sync nodes) |
 
 ## Contributing
 

--- a/crates/engine-api/src/api.rs
+++ b/crates/engine-api/src/api.rs
@@ -6,7 +6,9 @@
 
 use crate::EngineApiResult;
 use alloy_primitives::B256;
-use morph_payload_types::{AssembleL2BlockParams, ExecutableL2Data, GenericResponse, SafeL2Data};
+use morph_payload_types::{
+    AssembleL2BlockParams, BatchSignature, ExecutableL2Data, GenericResponse, SafeL2Data,
+};
 use morph_primitives::MorphHeader;
 
 /// Morph L2 Engine API trait.
@@ -107,4 +109,16 @@ pub trait MorphL2EngineApi: Send + Sync {
         safe_block_hash: B256,
         finalized_block_hash: B256,
     ) -> EngineApiResult<()>;
+
+    /// Append a BLS batch signature for a given batch hash.
+    ///
+    /// Called by the consensus layer when collecting validator signatures for
+    /// L1 batch submission. For non-sequencer sync nodes, this is a no-op.
+    async fn append_batch_signature(
+        &self,
+        _batch_hash: B256,
+        _signature: BatchSignature,
+    ) -> EngineApiResult<()> {
+        Ok(())
+    }
 }

--- a/crates/engine-api/src/rpc.rs
+++ b/crates/engine-api/src/rpc.rs
@@ -6,7 +6,9 @@
 use crate::{EngineApiResult, api::MorphL2EngineApi};
 use alloy_primitives::B256;
 use jsonrpsee::{RpcModule, core::RpcResult, proc_macros::rpc};
-use morph_payload_types::{AssembleL2BlockParams, ExecutableL2Data, GenericResponse, SafeL2Data};
+use morph_payload_types::{
+    AssembleL2BlockParams, BatchSignature, ExecutableL2Data, GenericResponse, SafeL2Data,
+};
 use morph_primitives::MorphHeader;
 use reth_rpc_api::IntoEngineApiRpcModule;
 use std::sync::Arc;
@@ -60,6 +62,22 @@ pub trait MorphL2EngineRpc {
         &self,
         safe_block_hash: B256,
         finalized_block_hash: B256,
+    ) -> RpcResult<()>;
+
+    /// Append a BLS batch signature for a given batch hash.
+    ///
+    /// Called by the consensus layer when collecting validator signatures for
+    /// L1 batch submission. Non-sequencer sync nodes accept this call but do
+    /// not persist the signature.
+    ///
+    /// # JSON-RPC Method
+    ///
+    /// `engine_appendBatchSignature`
+    #[method(name = "appendBatchSignature")]
+    async fn append_batch_signature(
+        &self,
+        batch_hash: B256,
+        signature: BatchSignature,
     ) -> RpcResult<()>;
 }
 
@@ -161,6 +179,25 @@ where
             .await
             .map_err(|e| {
                 tracing::error!(target: "morph::engine", error = %e, "failed to set block tags");
+                e.into()
+            })
+    }
+
+    async fn append_batch_signature(
+        &self,
+        batch_hash: B256,
+        _signature: BatchSignature,
+    ) -> RpcResult<()> {
+        tracing::debug!(
+            target: "morph::engine",
+            %batch_hash,
+            "RPC appendBatchSignature called (no-op for sync node)"
+        );
+        self.inner
+            .append_batch_signature(batch_hash, _signature)
+            .await
+            .map_err(|e| {
+                tracing::error!(target: "morph::engine", error = %e, "failed to append batch signature");
                 e.into()
             })
     }

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -35,7 +35,7 @@ use reth_ethereum_primitives as _;
 pub use attributes::{MorphPayloadAttributes, MorphPayloadBuilderAttributes};
 pub use built::MorphBuiltPayload;
 pub use executable_l2_data::ExecutableL2Data;
-pub use params::{AssembleL2BlockParams, GenericResponse};
+pub use params::{AssembleL2BlockParams, BatchSignature, GenericResponse};
 pub use safe_l2_data::SafeL2Data;
 
 // =============================================================================

--- a/crates/payload/types/src/params.rs
+++ b/crates/payload/types/src/params.rs
@@ -1,6 +1,6 @@
 //! Request/response types for L2 Engine API methods.
 
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, Bytes};
 
 /// Parameters for engine_assembleL2Block.
 ///
@@ -68,6 +68,22 @@ impl GenericResponse {
     pub fn failure() -> Self {
         Self { success: false }
     }
+}
+
+/// BLS batch signature from a sequencer validator.
+///
+/// This is sent by the consensus layer via `engine_appendBatchSignature`
+/// when collecting validator signatures for L1 batch submission.
+/// For non-sequencer nodes this is accepted but not persisted.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchSignature {
+    /// Validator address that produced the signature.
+    pub signer: Address,
+    /// BLS public key of the signer.
+    pub signer_pub_key: Bytes,
+    /// BLS signature over the batch hash.
+    pub signature: Bytes,
 }
 
 impl From<bool> for GenericResponse {


### PR DESCRIPTION
## Summary

- Add `engine_appendBatchSignature` no-op stub to the Morph L2 Engine API
- Unblocks sync nodes that get stuck after switching from blocksync to consensus mode

## Problem

After a sync node completes fast sync (blocksync), Tendermint switches it to consensus mode to follow the live chain. In consensus mode, it receives precommit votes from validators. When a vote carries a `BatchHash`, the consensus state machine calls `AppendBlsData` → `engine_appendBatchSignature` on the execution layer.

morph-reth doesn't implement this method, returning "Method not found". The morphnode's `retryableError()` treats this as retryable, triggering exponential backoff retries for up to **30 minutes per vote**. This blocks the consensus goroutine entirely, preventing `newL2Block` from being called and halting block import.

## Root Cause Trace

```
tendermint consensus/state.go:2288  addVote()
  └── vote.BlockID.BatchHash non-empty → AppendBlsData()
        └── node/core/batch.go:284 → retryClient.AppendBlsSignature()
              └── engine_appendBatchSignature RPC → "Method not found"
                    └── retryableError() == true → backoff.Retry (max 30min)
                          └── consensus goroutine blocked → no new blocks
```

## Fix

For non-sequencer sync nodes, BLS batch signatures are not needed (only sequencers aggregate them for L1 batch submission via `CommitBatch`). A no-op implementation that returns `Ok(())` immediately unblocks the consensus state machine.

## Changes

| File | Change |
|------|--------|
| `crates/payload/types/src/params.rs` | Add `BatchSignature` type |
| `crates/payload/types/src/lib.rs` | Export `BatchSignature` |
| `crates/engine-api/src/api.rs` | Add `append_batch_signature` default no-op to trait |
| `crates/engine-api/src/rpc.rs` | Register `engine_appendBatchSignature` JSON-RPC endpoint |
| `README.md` | Update Engine API method table |

## Test plan

- [x] `cargo test -p morph-engine-api -p morph-payload-types` — 60 tests pass
- [x] `cargo clippy -p morph-engine-api -- -D warnings` — clean
- [ ] Deploy rebuilt binary and verify sync node resumes block import after switching to consensus mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `engine_appendBatchSignature` Engine API method that accepts BLS batch signatures and batch hashes from the consensus layer. Compatible with both sequencer and sync node configurations.

* **Documentation**
  * Updated Engine API documentation to include the new `appendBatchSignature` method and its behavior specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->