### PR TITLE
fix(evm): use sort_by_key to satisfy clippy unnecessary_sort_by lint

### DIFF
--- a/crates/evm/src/block/curie.rs
+++ b/crates/evm/src/block/curie.rs
@@ -126,7 +126,7 @@ mod tests {
             .storage
             .into_iter()
             .collect::<Vec<(U256, StorageSlot)>>();
-        storage.sort_by(|(a, _), (b, _)| a.cmp(b));
+        storage.sort_by_key(|(a, _)| *a);
 
         let expected_storage = [
             (GPO_L1_BLOB_BASE_FEE_SLOT, INITIAL_L1_BLOB_BASE_FEE),


### PR DESCRIPTION
## Summary

- Fix `clippy::unnecessary_sort_by` lint in `crates/evm/src/block/curie.rs:129`
- Change `sort_by(|(a, _), (b, _)| a.cmp(b))` → `sort_by_key(|(a, _)| *a)`

## Background

CI upgraded to Rust 1.95.0 which introduced the `unnecessary_sort_by` lint as a warning. Local dev still on 1.92.0 so this wasn't caught before merging. Blocking dependabot PR #99.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal sorting logic for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->