### PR TITLE
chore: port build profile gradient from tempo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,14 @@ on:
         description: "Dry run (skip release creation)"
         type: boolean
         default: true
+      profile:
+        description: "Cargo profile for release binaries"
+        type: choice
+        default: "profiling"
+        options:
+          - profiling
+          - maxperf
+          - release
 
 permissions:
   contents: read
@@ -102,13 +110,33 @@ jobs:
       - name: Install cross main
         run: cargo install cross --git https://github.com/cross-rs/cross
 
+      - name: Resolve build profile
+        id: profile
+        run: |
+          # Tag push -> maxperf (peak throughput for public releases).
+          # workflow_dispatch -> user-selected profile (defaults to profiling).
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            PROFILE="${{ inputs.profile }}"
+          else
+            PROFILE="maxperf"
+          fi
+          # Cargo's target dir is "debug" for dev, otherwise the profile name.
+          if [[ "$PROFILE" == "dev" ]]; then
+            PROFILE_DIR="debug"
+          else
+            PROFILE_DIR="$PROFILE"
+          fi
+          echo "profile=$PROFILE" >> "$GITHUB_OUTPUT"
+          echo "profile_dir=$PROFILE_DIR" >> "$GITHUB_OUTPUT"
+          echo "Resolved profile: $PROFILE (target dir: $PROFILE_DIR)"
+
       - name: Build binary
-        run: make build-${{ matrix.target }}
+        run: make build-${{ matrix.target }} PROFILE=${{ steps.profile.outputs.profile }}
 
       - name: Package binary
         run: |
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/morph-reth dist/
+          cp target/${{ matrix.target }}/${{ steps.profile.outputs.profile_dir }}/morph-reth dist/
           cd dist
           tar czf ../${{ matrix.archive }}.tar.gz morph-reth
           cd ..

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,50 @@ unnameable-types = "warn"
 [workspace.lints.rustdoc]
 all = "warn"
 
+# Build profiles ported from the sibling `tempo` project.
+
+# Speed up compilation time for dev builds by reducing emitted debug info.
+# NOTE: Debuggers may provide less useful information with this setting.
+# Uncomment this section if you're using a debugger.
+[profile.dev]
+# https://davidlattimore.github.io/posts/2024/02/04/speeding-up-the-rust-edit-build-run-cycle.html
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+
+# Meant for testing - all optimizations, but with debug assertions and overflow checks.
+[profile.hivetests]
+inherits = "test"
+opt-level = 3
+lto = "thin"
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+debug = "none"
+strip = "symbols"
+panic = "unwind"
+codegen-units = 16
+
+# Use the `--profile profiling` flag to keep line-table symbols in a release
+# build — suitable for production flame graphs.
+# e.g. `cargo build --profile profiling`
+[profile.profiling]
+inherits = "release"
+debug = "line-tables-only"
+strip = "none"
+incremental = true
+
+# Include debug info in benchmarks too.
+[profile.bench]
+inherits = "profiling"
+
+# Maximum runtime performance. Fat LTO + single codegen unit; use for
+# throughput-sensitive production binaries (expect noticeably slower link).
+[profile.maxperf]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+
 [workspace.dependencies]
 morph-chainspec = { path = "crates/chainspec", default-features = false }
 morph-consensus = { path = "crates/consensus", default-features = false }

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,11 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 
-# Build profile, release by default
-ARG BUILD_PROFILE=release
+# Build profile. Defaults to `profiling` (release + line-table symbols) so
+# production binaries remain flame-graphable. Override with
+# `--build-arg BUILD_PROFILE=maxperf` for peak throughput (fat LTO, slower
+# to link) or `release` for the slimmer/stripped variant.
+ARG BUILD_PROFILE=profiling
 ENV BUILD_PROFILE=$BUILD_PROFILE
 
 # Extra Cargo flags

--- a/MakefileEc2.mk
+++ b/MakefileEc2.mk
@@ -5,7 +5,10 @@ DIST_DIR         = dist
 BINARY           = morph-reth
 TARBALL          = morph-reth.tar.gz
 CARGO_TARGET_DIR ?= target
-PROFILE          ?= release
+# Production deploys go to EC2 via S3. Default to `profiling` so the shipped
+# binaries keep line-table symbols and remain flame-graphable in prod (matches
+# the Dockerfile default). Override with `PROFILE=maxperf` for peak throughput.
+PROFILE          ?= profiling
 
 define cargo_build_and_upload
 	if [ ! -d $(DIST_DIR) ]; then mkdir -p $(DIST_DIR); fi

--- a/crates/evm/src/block/curie.rs
+++ b/crates/evm/src/block/curie.rs
@@ -126,7 +126,7 @@ mod tests {
             .storage
             .into_iter()
             .collect::<Vec<(U256, StorageSlot)>>();
-        storage.sort_by(|(a, _), (b, _)| a.cmp(b));
+        storage.sort_by_key(|(a, _)| *a);
 
         let expected_storage = [
             (GPO_L1_BLOB_BASE_FEE_SLOT, INITIAL_L1_BLOB_BASE_FEE),


### PR DESCRIPTION
## Summary

morph-reth's root `Cargo.toml` previously defined **no `[profile.*]` overrides**, so release builds fell back to Cargo defaults (`lto = off`) — worse than even upstream reth's own `release`. This PR mirrors the profile shape used by the sibling **`tempo`** project and aligns the Dockerfile, release workflow, and EC2 deploy Makefile so that every shipped artifact uses an intentional profile.

Commit-by-commit:

1. **`chore(evm): silence clippy unnecessary_sort_by in curie.rs test`** — pre-existing clippy 1.95 error on `main` that blocks the CI lint job. Cherry-picked from the dev branch. Independent fix, kept first so the rest of the PR can pass lint.
2. **`chore(cargo): port build profile gradient from tempo`** — adds `dev` / `hivetests` / `release` / `profiling` / `bench` / `maxperf` with the exact settings tempo uses. No changes to `[workspace.lints]` (already matches tempo).
3. **`chore(docker): default BUILD_PROFILE to profiling`** — production Docker images now default to `profiling` (release + line-table symbols) so they remain flame-graphable. Override with `--build-arg BUILD_PROFILE=maxperf` or `release`.
4. **`ci(release): parameterize cargo profile; default tag-push to maxperf`** — release workflow no longer hardcodes `target/.../release/`. Push-tag triggers use `maxperf` for peak throughput; `workflow_dispatch` exposes a `profile` input (default `profiling`). `MakefileEc2.mk` default also flips to `profiling` to match the Dockerfile, so S3-deployed EC2 binaries stay flame-graphable in prod.

## Profile choice matrix (after this PR)

| Artifact | Profile | Reason |
|---|---|---|
| `make build` (local dev) | `release` *(unchanged)* | Fast link, good iteration loop |
| Docker images (`ghcr.io/.../morph-reth`) | `profiling` | Flame-graphable prod; near-zero runtime cost vs release |
| S3-deployed EC2 binaries (`MakefileEc2.mk`) | `profiling` | Consistency with Docker for prod debugging |
| GitHub Release tarballs (tag push) | `maxperf` | Peak throughput for public consumers |
| GitHub Release tarballs (manual dispatch) | `profiling` *(user-selectable)* | Flame-graphable debug artifacts |

## Test plan

- [x] `cargo metadata` parses with new profile section
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all --all-targets -- -D warnings` passes (curie fix lands first)
- [x] `cargo check --profile profiling --bin morph-reth` builds cleanly
- [ ] CI `lint` / `test` / `build` workflows green on the PR
- [ ] Dry-run release via `workflow_dispatch` with default `profile=profiling` produces a valid tarball
- [ ] Follow-up: also verify a `maxperf` dispatch run once ready to cut a tag

## Non-goals / deliberately skipped

- **Lints section is untouched.** `[workspace.lints]` already matches tempo; no changes.
- **Makefile default `PROFILE ?= release` is unchanged.** Daily `make build` / `make test` / `make lint` behave identically to today. Only the release pipeline and EC2 deploy override the default.
- **Did not port upstream `paradigmxyz/reth`'s clippy nursery** (too aggressive for this codebase; ~120 findings without much benefit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration with new Cargo profiles supporting different optimization levels and debugging requirements.
  * Changed default build profile from `release` to `profiling` for improved debuggability in production environments while maintaining performance.
  * Added configurable build profile selection for Docker and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->