### PR TITLE
refactor(engine-api): remove engine_appendBatchSignature and BatchSignature

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ Morph provides a custom L2 Engine API (different from the standard Ethereum Engi
 | `engine_newL2Block` | Import a new L2 block via `newPayload` + `forkchoiceUpdated` and advance the canonical head |
 | `engine_newSafeL2Block` | Rebuild and import a safe L2 block from derivation inputs |
 | `engine_setBlockTags` | Update safe/finalized block tags without importing a block |
-| `engine_appendBatchSignature` | Accept a BLS batch signature from the consensus layer (no-op for sync nodes) |
 
 ## Contributing
 

--- a/crates/engine-api/src/api.rs
+++ b/crates/engine-api/src/api.rs
@@ -7,7 +7,7 @@
 use crate::EngineApiResult;
 use alloy_primitives::B256;
 use morph_payload_types::{
-    AssembleL2BlockParams, BatchSignature, ExecutableL2Data, GenericResponse, SafeL2Data,
+    AssembleL2BlockParams, ExecutableL2Data, GenericResponse, SafeL2Data,
 };
 use morph_primitives::MorphHeader;
 
@@ -109,16 +109,4 @@ pub trait MorphL2EngineApi: Send + Sync {
         safe_block_hash: B256,
         finalized_block_hash: B256,
     ) -> EngineApiResult<()>;
-
-    /// Append a BLS batch signature for a given batch hash.
-    ///
-    /// Called by the consensus layer when collecting validator signatures for
-    /// L1 batch submission. For non-sequencer sync nodes, this is a no-op.
-    async fn append_batch_signature(
-        &self,
-        _batch_hash: B256,
-        _signature: BatchSignature,
-    ) -> EngineApiResult<()> {
-        Ok(())
-    }
 }

--- a/crates/engine-api/src/api.rs
+++ b/crates/engine-api/src/api.rs
@@ -6,9 +6,7 @@
 
 use crate::EngineApiResult;
 use alloy_primitives::B256;
-use morph_payload_types::{
-    AssembleL2BlockParams, ExecutableL2Data, GenericResponse, SafeL2Data,
-};
+use morph_payload_types::{AssembleL2BlockParams, ExecutableL2Data, GenericResponse, SafeL2Data};
 use morph_primitives::MorphHeader;
 
 /// Morph L2 Engine API trait.

--- a/crates/engine-api/src/rpc.rs
+++ b/crates/engine-api/src/rpc.rs
@@ -7,7 +7,7 @@ use crate::{EngineApiResult, api::MorphL2EngineApi};
 use alloy_primitives::B256;
 use jsonrpsee::{RpcModule, core::RpcResult, proc_macros::rpc};
 use morph_payload_types::{
-    AssembleL2BlockParams, BatchSignature, ExecutableL2Data, GenericResponse, SafeL2Data,
+    AssembleL2BlockParams, ExecutableL2Data, GenericResponse, SafeL2Data,
 };
 use morph_primitives::MorphHeader;
 use reth_rpc_api::IntoEngineApiRpcModule;
@@ -62,22 +62,6 @@ pub trait MorphL2EngineRpc {
         &self,
         safe_block_hash: B256,
         finalized_block_hash: B256,
-    ) -> RpcResult<()>;
-
-    /// Append a BLS batch signature for a given batch hash.
-    ///
-    /// Called by the consensus layer when collecting validator signatures for
-    /// L1 batch submission. Non-sequencer sync nodes accept this call but do
-    /// not persist the signature.
-    ///
-    /// # JSON-RPC Method
-    ///
-    /// `engine_appendBatchSignature`
-    #[method(name = "appendBatchSignature")]
-    async fn append_batch_signature(
-        &self,
-        batch_hash: B256,
-        signature: BatchSignature,
     ) -> RpcResult<()>;
 }
 
@@ -179,25 +163,6 @@ where
             .await
             .map_err(|e| {
                 tracing::error!(target: "morph::engine", error = %e, "failed to set block tags");
-                e.into()
-            })
-    }
-
-    async fn append_batch_signature(
-        &self,
-        batch_hash: B256,
-        _signature: BatchSignature,
-    ) -> RpcResult<()> {
-        tracing::debug!(
-            target: "morph::engine",
-            %batch_hash,
-            "RPC appendBatchSignature called (no-op for sync node)"
-        );
-        self.inner
-            .append_batch_signature(batch_hash, _signature)
-            .await
-            .map_err(|e| {
-                tracing::error!(target: "morph::engine", error = %e, "failed to append batch signature");
                 e.into()
             })
     }

--- a/crates/engine-api/src/rpc.rs
+++ b/crates/engine-api/src/rpc.rs
@@ -6,9 +6,7 @@
 use crate::{EngineApiResult, api::MorphL2EngineApi};
 use alloy_primitives::B256;
 use jsonrpsee::{RpcModule, core::RpcResult, proc_macros::rpc};
-use morph_payload_types::{
-    AssembleL2BlockParams, ExecutableL2Data, GenericResponse, SafeL2Data,
-};
+use morph_payload_types::{AssembleL2BlockParams, ExecutableL2Data, GenericResponse, SafeL2Data};
 use morph_primitives::MorphHeader;
 use reth_rpc_api::IntoEngineApiRpcModule;
 use std::sync::Arc;

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -35,7 +35,7 @@ use reth_ethereum_primitives as _;
 pub use attributes::{MorphPayloadAttributes, MorphPayloadBuilderAttributes};
 pub use built::MorphBuiltPayload;
 pub use executable_l2_data::ExecutableL2Data;
-pub use params::{AssembleL2BlockParams, BatchSignature, GenericResponse};
+pub use params::{AssembleL2BlockParams, GenericResponse};
 pub use safe_l2_data::SafeL2Data;
 
 // =============================================================================

--- a/crates/payload/types/src/params.rs
+++ b/crates/payload/types/src/params.rs
@@ -1,6 +1,6 @@
 //! Request/response types for L2 Engine API methods.
 
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::Bytes;
 
 /// Parameters for engine_assembleL2Block.
 ///
@@ -68,22 +68,6 @@ impl GenericResponse {
     pub fn failure() -> Self {
         Self { success: false }
     }
-}
-
-/// BLS batch signature from a sequencer validator.
-///
-/// This is sent by the consensus layer via `engine_appendBatchSignature`
-/// when collecting validator signatures for L1 batch submission.
-/// For non-sequencer nodes this is accepted but not persisted.
-#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BatchSignature {
-    /// Validator address that produced the signature.
-    pub signer: Address,
-    /// BLS public key of the signer.
-    pub signer_pub_key: Bytes,
-    /// BLS signature over the batch hash.
-    pub signature: Bytes,
 }
 
 impl From<bool> for GenericResponse {


### PR DESCRIPTION
## Summary

Remove the `engine_appendBatchSignature` RPC stub and the `BatchSignature` type. The consensus layer (tendermint / morphnode) no longer calls this method after batch generation is moved out of the consensus path to the `tx-submitter`.

## Cross-repo coordination

This PR is the morph-reth counterpart of:
- **morph-l2/go-ethereum#319** — remove sequencer batch write paths + drop unused `NewL2Block` batch hash
- **morph-l2/tendermint#35** — remove sequencer batch generation from consensus layer
- **morph-l2/morph#939** — remove sequencer batch generation and BLS signing

## Scope

morph-reth only ever carried a no-op stub for `engine_appendBatchSignature` (added in #93 to prevent morphnode's retry loop from hanging the tendermint goroutine). morph-reth never implemented the geth-side batch write paths (`CommitBatch`, `RollupBatch` DB accessors, `batch.Handler` lifecycle), so there is no equivalent cleanup needed here — only the stub goes away.

`batch_hash` was already removed from `MorphHeader` in #31, and `newL2Block` already has no `batchHash` parameter in reth.

## Changes

- Delete `append_batch_signature` default method from `MorphL2EngineApi` trait (`crates/engine-api/src/api.rs`)
- Delete `append_batch_signature` method from `MorphL2EngineRpc` trait + `MorphL2EngineRpcHandler` impl (`crates/engine-api/src/rpc.rs`)
- Delete `BatchSignature` struct (`crates/payload/types/src/params.rs`)
- Drop `BatchSignature` re-export (`crates/payload/types/src/lib.rs`)
- Drop `engine_appendBatchSignature` row from README Engine API table

Net diff: **5 files, +4 / -68**.

## Deployment ordering

This PR should land together with (or after) the coordinated PRs in go-ethereum / tendermint / morph. Running a newer morph-reth without the `engine_appendBatchSignature` endpoint against an older morphnode that still calls it would trigger the same "Method not found" retry storm that #93 originally fixed.

## Test plan

- [ ] `cargo check --workspace`
- [ ] `cargo clippy --all --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] Smoke test against a morphnode built from morph-l2/morph#939 (no retry storm, blocks continue to sync)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `appendBatchSignature` API method from the Engine API along with its type definitions and JSON-RPC endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->