### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4715,7 +4715,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "morph-chainspec"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4738,7 +4738,7 @@ dependencies = [
 
 [[package]]
 name = "morph-consensus"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -4756,7 +4756,7 @@ dependencies = [
 
 [[package]]
 name = "morph-engine-api"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4785,7 +4785,7 @@ dependencies = [
 
 [[package]]
 name = "morph-evm"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "morph-node"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "morph-payload-builder"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4903,7 +4903,7 @@ dependencies = [
 
 [[package]]
 name = "morph-payload-types"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "morph-primitives"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4944,7 +4944,7 @@ dependencies = [
 
 [[package]]
 name = "morph-reference-index"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4969,7 +4969,7 @@ dependencies = [
 
 [[package]]
 name = "morph-reth"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "clap",
  "eyre",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "morph-revm"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "morph-rpc"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5053,7 +5053,7 @@ dependencies = [
 
 [[package]]
 name = "morph-txpool"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Prepares the v0.3.0 release. Bumps `[workspace.package].version` from `0.2.2` to `0.3.0` and refreshes `Cargo.lock` so all 13 internal `morph-*` crates carry the new version.

Highlights since v0.2.2 (5 PRs):

- **feat:** `morph_getTransactionHashesByReference` RPC + `morph-reference-index` ExEx (#106)
- **breaking:** removed `engine_appendBatchSignature` / `BatchSignature` — consensus already stopped calling it (#105)
- **chore:** workspace build-profile gradient, prod deploys default to `profiling`, x86-64-v3 baseline for x86_64 release artifacts (#104)
- **refactor:** dropped unreachable `apply_curie_hard_fork` dead code (#101)
- **fix(clippy):** `unnecessary_sort_by` lint cleanup (#100)

A `breaking` change (#105) plus a sizable new feature (#106) warrant a minor bump per pre-1.0 SemVer.

## Test plan

- [ ] CI green on this PR (build + clippy + cargo-deny + tests)
- [ ] After merge, tag `v0.3.0` from `main` and push to `origin` (GitHub release CI) and `gitlab`
- [ ] Push `release/0.3.0` branch to `gitlab` for deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.3.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/morph-l2/morph-reth/pull/107)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->