### PR TITLE
fix: address audit follow-ups

### DIFF
--- a/crates/consensus/src/validation.rs
+++ b/crates/consensus/src/validation.rs
@@ -719,6 +719,7 @@ mod tests {
                 "morph203Time": 0,
                 "viridianTime": 0,
                 "emeraldTime": 0,
+                "jadeForkTime": 0,
                 "morph": {}
             },
             "alloc": {}
@@ -747,6 +748,31 @@ mod tests {
         let tx = TxLegacy::default();
         let sig = Signature::new(U256::ZERO, U256::ZERO, false);
         MorphTxEnvelope::Legacy(Signed::new_unchecked(tx, sig, B256::ZERO))
+    }
+
+    fn create_sealed_block(
+        timestamp: u64,
+        transactions: Vec<MorphTxEnvelope>,
+    ) -> SealedBlock<Block> {
+        use alloy_consensus::proofs::calculate_transaction_root;
+        use reth_primitives_traits::Block as _;
+
+        let transactions_root = calculate_transaction_root(&transactions);
+        let header = create_morph_header(Header {
+            timestamp,
+            transactions_root,
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            ..Default::default()
+        });
+        Block::new(
+            header,
+            BlockBody {
+                transactions,
+                ommers: Default::default(),
+                withdrawals: None,
+            },
+        )
+        .seal_slow()
     }
 
     /// Create a MorphHeader from a standard Header
@@ -1707,6 +1733,16 @@ mod tests {
         // V1 after jade fork should pass
         let txs = [create_morph_tx_v1(1)];
         let result = validate_morph_txs(&txs, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_block_pre_execution_uses_chainspec_jade_activation() {
+        let consensus = MorphConsensus::new(create_test_chainspec());
+        let block = create_sealed_block(0, vec![create_morph_tx_v1(1)]);
+
+        let result = consensus.validate_block_pre_execution(&block);
+
         assert!(result.is_ok());
     }
 

--- a/crates/engine-api/src/builder.rs
+++ b/crates/engine-api/src/builder.rs
@@ -512,16 +512,43 @@ where
         // stale older value — a transient `finalized > safe` violation. Updating
         // safe first keeps the invariant satisfied throughout (finalized stays
         // at its older, smaller value while safe advances).
-        if safe_block_hash != B256::ZERO {
-            self.update_block_tag(safe_block_hash, "safe", |sealed| {
-                self.provider.set_safe(sealed);
-            })?;
+        let safe = if safe_block_hash != B256::ZERO {
+            Some(self.resolve_block_tag(safe_block_hash, "safe")?)
+        } else {
+            None
+        };
+        let finalized = if finalized_block_hash != B256::ZERO {
+            Some(self.resolve_block_tag(finalized_block_hash, "finalized")?)
+        } else {
+            None
+        };
+        if safe.is_none() && finalized.is_none() {
+            return Ok(());
         }
 
-        if finalized_block_hash != B256::ZERO {
-            self.update_block_tag(finalized_block_hash, "finalized", |sealed| {
-                self.provider.set_finalized(sealed);
-            })?;
+        let canonical_head = self.current_head()?;
+        validate_resolved_block_tags(
+            safe.as_ref().map(|header| header.number()),
+            finalized.as_ref().map(|header| header.number()),
+            canonical_head.number,
+        )?;
+
+        if let Some(sealed) = safe {
+            self.provider.set_safe(sealed);
+            tracing::info!(
+                target: "morph::engine",
+                hash = %safe_block_hash,
+                "safe block tag updated"
+            );
+        }
+
+        if let Some(sealed) = finalized {
+            self.provider.set_finalized(sealed);
+            tracing::info!(
+                target: "morph::engine",
+                hash = %finalized_block_hash,
+                "finalized block tag updated"
+            );
         }
 
         // Cache the L1-based hashes so subsequent FCU calls use them instead of
@@ -545,32 +572,23 @@ where
 }
 
 impl<Provider> RealMorphL2EngineApi<Provider> {
-    /// Looks up a sealed header by hash, calls `setter` on it, and logs the tag update.
+    /// Looks up a sealed header by hash.
     ///
-    /// Used by `set_block_tags` to deduplicate the finalized/safe update paths.
-    fn update_block_tag(
+    /// Used by `set_block_tags` to validate both tag updates before mutating provider state.
+    fn resolve_block_tag(
         &self,
         hash: B256,
         tag_name: &str,
-        setter: impl FnOnce(SealedHeader<MorphHeader>),
-    ) -> EngineApiResult<()>
+    ) -> EngineApiResult<SealedHeader<MorphHeader>>
     where
         Provider: HeaderProvider<Header = MorphHeader>,
     {
-        let sealed = self
-            .provider
+        self.provider
             .sealed_header_by_hash(hash)
             .map_err(|e| MorphEngineApiError::Internal(e.to_string()))?
             .ok_or_else(|| {
                 MorphEngineApiError::Internal(format!("{tag_name} block {hash} not found"))
-            })?;
-        setter(sealed);
-        tracing::info!(
-            target: "morph::engine",
-            %hash,
-            "{tag_name} block tag updated"
-        );
-        Ok(())
+            })
     }
 
     async fn build_l2_payload(
@@ -908,6 +926,41 @@ impl<Provider> RealMorphL2EngineApi<Provider> {
     }
 }
 
+fn validate_resolved_block_tags(
+    safe_number: Option<u64>,
+    finalized_number: Option<u64>,
+    canonical_head_number: u64,
+) -> EngineApiResult<()> {
+    if let Some(safe_number) = safe_number
+        && safe_number > canonical_head_number
+    {
+        return Err(MorphEngineApiError::ValidationFailed(format!(
+            "safe block number {} exceeds canonical head number {}",
+            safe_number, canonical_head_number
+        )));
+    }
+
+    if let Some(finalized_number) = finalized_number
+        && finalized_number > canonical_head_number
+    {
+        return Err(MorphEngineApiError::ValidationFailed(format!(
+            "finalized block number {} exceeds canonical head number {}",
+            finalized_number, canonical_head_number
+        )));
+    }
+
+    if let (Some(safe_number), Some(finalized_number)) = (safe_number, finalized_number)
+        && finalized_number > safe_number
+    {
+        return Err(MorphEngineApiError::ValidationFailed(format!(
+            "finalized block number {} exceeds safe block number {}",
+            finalized_number, safe_number
+        )));
+    }
+
+    Ok(())
+}
+
 fn payload_status_is_validated(status: &PayloadStatus) -> bool {
     matches!(status.status, PayloadStatusEnum::Valid)
 }
@@ -1237,6 +1290,28 @@ mod tests {
 
         assert_eq!(tracker.l1_safe_hash(), Some(safe_hash));
         assert_eq!(tracker.l1_finalized_hash(), Some(finalized_hash));
+    }
+
+    #[test]
+    fn test_validate_resolved_block_tags_rejects_finalized_after_safe() {
+        let err = validate_resolved_block_tags(Some(10), Some(11), 11).unwrap_err();
+        match err {
+            MorphEngineApiError::ValidationFailed(msg) => {
+                assert!(msg.contains("finalized block number 11 exceeds safe block number 10"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_resolved_block_tags_rejects_safe_after_canonical_head() {
+        let err = validate_resolved_block_tags(Some(12), Some(11), 11).unwrap_err();
+        match err {
+            MorphEngineApiError::ValidationFailed(msg) => {
+                assert!(msg.contains("safe block number 12 exceeds canonical head number 11"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
     }
 
     // =========================================================================

--- a/crates/engine-api/src/builder.rs
+++ b/crates/engine-api/src/builder.rs
@@ -935,8 +935,7 @@ fn validate_resolved_block_tags(
         && safe_number > canonical_head_number
     {
         return Err(MorphEngineApiError::ValidationFailed(format!(
-            "safe block number {} exceeds canonical head number {}",
-            safe_number, canonical_head_number
+            "safe block number {safe_number} exceeds canonical head number {canonical_head_number}"
         )));
     }
 
@@ -944,8 +943,7 @@ fn validate_resolved_block_tags(
         && finalized_number > canonical_head_number
     {
         return Err(MorphEngineApiError::ValidationFailed(format!(
-            "finalized block number {} exceeds canonical head number {}",
-            finalized_number, canonical_head_number
+            "finalized block number {finalized_number} exceeds canonical head number {canonical_head_number}"
         )));
     }
 
@@ -953,8 +951,7 @@ fn validate_resolved_block_tags(
         && finalized_number > safe_number
     {
         return Err(MorphEngineApiError::ValidationFailed(format!(
-            "finalized block number {} exceeds safe block number {}",
-            finalized_number, safe_number
+            "finalized block number {finalized_number} exceeds safe block number {safe_number}"
         )));
     }
 

--- a/crates/reference-index/src/backfill.rs
+++ b/crates/reference-index/src/backfill.rs
@@ -103,6 +103,8 @@ where
         + HeaderProvider<Header = MorphHeader>,
     CS: MorphHardforks,
 {
+    validate_backfill_batch_size(batch_size)?;
+
     let state = db.backfill_state()?;
 
     // `jade_first_block_number` is our canonical lower bound; it's written as the
@@ -233,6 +235,13 @@ where
     Ok(())
 }
 
+fn validate_backfill_batch_size(batch_size: u64) -> Result<(), ReferenceIndexError> {
+    if batch_size == 0 {
+        return Err(ReferenceIndexError::InvalidBackfillBatchSize);
+    }
+    Ok(())
+}
+
 /// Re-validate and (if needed) reset `jade_first_block_number` when the DB
 /// was opened with a sentinel value (`u64::MAX`) from a previous run where
 /// Jade had not yet activated.
@@ -298,5 +307,13 @@ mod tests {
             BackfillState::Complete
         );
         assert!(BackfillState::try_from(3u8).is_err());
+    }
+
+    #[test]
+    fn backfill_batch_size_zero_is_rejected() {
+        assert!(matches!(
+            validate_backfill_batch_size(0),
+            Err(ReferenceIndexError::InvalidBackfillBatchSize)
+        ));
     }
 }

--- a/crates/reference-index/src/types.rs
+++ b/crates/reference-index/src/types.rs
@@ -32,9 +32,9 @@ impl TryFrom<u8> for BackfillState {
 /// Validated query parameters for reference lookups.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReferenceQuery {
-    pub reference: B256,
-    pub offset: u64,
-    pub limit: u64,
+    pub(crate) reference: B256,
+    pub(crate) offset: u64,
+    pub(crate) limit: u64,
 }
 
 impl ReferenceQuery {
@@ -88,6 +88,8 @@ pub enum ReferenceIndexError {
     OffsetTooLarge { offset: u64 },
     #[error("invalid backfill state: {0}")]
     InvalidBackfillState(u8),
+    #[error("reference index backfill batch size must be greater than zero")]
+    InvalidBackfillBatchSize,
     #[error("reference index chain identity mismatch: {0}")]
     ChainIdentityMismatch(&'static str),
     #[error("reference index schema mismatch: expected {expected}, got {actual}")]

--- a/crates/revm/src/precompiles.rs
+++ b/crates/revm/src/precompiles.rs
@@ -116,8 +116,9 @@ impl MorphPrecompiles {
             MorphHardfork::Bernoulli | MorphHardfork::Curie => bernoulli(),
             // Morph203 and Viridian share the same precompile set
             MorphHardfork::Morph203 | MorphHardfork::Viridian => morph203(),
-            // Emerald: adds Osaka precompiles (P256verify, BLS12-381, etc)
-            MorphHardfork::Emerald | _ => emerald(),
+            // Emerald and Jade share the same precompile set.
+            MorphHardfork::Emerald | MorphHardfork::Jade => emerald(),
+            hardfork => unreachable!("unsupported Morph hardfork: {hardfork:?}"),
         };
 
         Self {

--- a/crates/txpool/src/validator.rs
+++ b/crates/txpool/src/validator.rs
@@ -343,33 +343,17 @@ where
                 // the shared helper used by both admission and maintenance.
                 // Pass &MorphTxEnvelope directly to avoid a second clone_into_consensus().
                 let sender = valid_tx.transaction().sender();
-                let validation = match self.validate_morph_tx_balance(
+                if let Err(err) = self.validate_morph_tx_balance(
                     &consensus_tx,
                     sender,
                     balance,
                     l1_data_fee,
                     hardfork,
                 ) {
-                    Ok(v) => v,
-                    Err(err) => {
-                        return TransactionValidationOutcome::Invalid(
-                            valid_tx.into_transaction(),
-                            err.into(),
-                        );
-                    }
-                };
-
-                // MorphTx with fee_token_id = 0 uses ETH fee path and must pass
-                // the same ETH affordability check as regular txs.
-                if !validation.uses_token_fee {
-                    let cost = valid_tx.transaction().cost().saturating_add(l1_data_fee);
-                    if cost > balance {
-                        return insufficient_funds_outcome(
-                            valid_tx.into_transaction(),
-                            balance,
-                            cost,
-                        );
-                    }
+                    return TransactionValidationOutcome::Invalid(
+                        valid_tx.into_transaction(),
+                        err.into(),
+                    );
                 }
             } else {
                 // Regular transaction: validate ETH balance covers cost + L1 fee


### PR DESCRIPTION
## Summary
- Validate Engine API block tag updates before mutating provider state.
- Add reference-index, consensus, and revm hardening from the audit review.
- Remove duplicate MorphTx ETH affordability checking from txpool.

## Test plan
- `cargo fmt --all -- --check`
- `cargo test -p morph-engine-api -p morph-reference-index -p morph-consensus -p morph-revm -p morph-txpool`
- `cargo check -p morph-engine-api -p morph-reference-index -p morph-consensus -p morph-revm -p morph-txpool`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Jade hardfork support with explicit precompile configuration and validation.

* **Improvements**
  * Improved block tag validation ensuring safe/finalized blocks maintain proper ordering relative to canonical head.
  * Added batch size validation with clear error messages for invalid configurations.
  * Tightened hardfork handling to prevent unsupported hardforks from silently using fallback logic.

* **Tests**
  * Added tests validating Jade hardfork behavior and block tag consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->