### PR TITLE
fix(primitives): emit gasPrice=0x0 placeholder for L1 message RPC

### DIFF
--- a/crates/primitives/src/transaction/l1_transaction.rs
+++ b/crates/primitives/src/transaction/l1_transaction.rs
@@ -156,8 +156,16 @@ impl Transaction for TxL1Msg {
     }
 
     fn gas_price(&self) -> Option<u128> {
-        // L1 messages have no gas price - gas is paid on L1
-        None
+        // L1 messages have no gas price (gas is prepaid on L1), but RPC
+        // serialization must surface a `"gasPrice": "0x0"` field to match
+        // morph-geth's contract — indexers compute fees from this value and
+        // would otherwise see a non-zero figure (the block baseFee picked up
+        // by alloy's generic `from_consensus_tx` path). Returning `Some(0)`
+        // here also tells `alloy_rpc_types_eth::Transaction`'s serde helper
+        // not to emit an outer `effective_gas_price` for this variant, so
+        // the inner placeholder added in `L1MsgSerdeHelper` is the single
+        // source of truth.
+        Some(0)
     }
 
     fn max_fee_per_gas(&self) -> u128 {
@@ -354,6 +362,8 @@ mod msg_serde {
         // RPC parity placeholders. Always serialized as `"0x0"`; ignored on deserialize.
         #[serde(default, with = "alloy_serde::quantity")]
         nonce: u64,
+        #[serde(default, rename = "gasPrice", with = "alloy_serde::quantity")]
+        gas_price: u64,
         #[serde(default, with = "alloy_serde::quantity")]
         v: u64,
         #[serde(default)]
@@ -387,6 +397,7 @@ mod msg_serde {
                 sender: tx.sender,
                 input: tx.input,
                 nonce: 0,
+                gas_price: 0,
                 v: 0,
                 r: U256::ZERO,
                 s: U256::ZERO,
@@ -438,7 +449,7 @@ mod tests {
         assert_eq!(tx.chain_id(), None);
         assert_eq!(Transaction::nonce(&tx), 0); // L1 messages always have nonce 0
         assert_eq!(Transaction::gas_limit(&tx), 21_000);
-        assert_eq!(tx.gas_price(), None); // L1 messages have no gas price
+        assert_eq!(tx.gas_price(), Some(0)); // L1 messages surface gasPrice=0 for RPC parity with morph-geth
         assert_eq!(tx.max_fee_per_gas(), 0);
         assert_eq!(tx.max_priority_fee_per_gas(), None);
         assert_eq!(tx.max_fee_per_blob_gas(), None);
@@ -662,6 +673,7 @@ mod tests {
         assert_eq!(json["gas"], "0x1e8480");
         assert_eq!(json["input"], "0x8ef1332e");
         assert_eq!(json["nonce"], "0x0");
+        assert_eq!(json["gasPrice"], "0x0");
         assert_eq!(json["v"], "0x0");
         assert_eq!(json["r"], "0x0");
         assert_eq!(json["s"], "0x0");
@@ -716,6 +728,7 @@ mod tests {
         );
         // morph-geth RPC parity placeholders, must all be present at the top level.
         assert_eq!(json["nonce"], "0x0");
+        assert_eq!(json["gasPrice"], "0x0");
         assert_eq!(json["v"], "0x0");
         assert_eq!(json["r"], "0x0");
         assert_eq!(json["s"], "0x0");

--- a/crates/rpc/src/eth/transaction.rs
+++ b/crates/rpc/src/eth/transaction.rs
@@ -710,6 +710,13 @@ mod tests {
         let json = serde_json::to_string(&rpc_tx).unwrap();
         assert_eq!(json.matches("\"sender\"").count(), 1);
         assert_eq!(json.matches("\"queueIndex\"").count(), 1);
+
+        // L1 messages must surface a single `"gasPrice":"0x0"` even though the
+        // outer block carries a non-zero baseFee — the alloy generic path would
+        // otherwise propagate baseFee into `gasPrice` and break fee indexers.
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["gasPrice"], "0x0");
+        assert_eq!(json.matches("\"gasPrice\"").count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- L1MessageTx (0x7e) RPC currently returns `gasPrice = blockBaseFee` (e.g. `0xf4240`) because the generic `alloy_rpc_types_eth::Transaction::from_consensus_tx` path picked up `effective_gas_price` as the outer placeholder.
- morph-geth returns `0x0` here. Indexers compute fees from this field and would otherwise be off by one block-baseFee per deposit.
- Make `TxL1Msg::gas_price()` return `Some(0)` (so alloy's serde helper stops emitting an outer placeholder) and add a `gasPrice` field to `L1MsgSerdeHelper` so the inner serialization is the single source of truth.
- Receipt path is untouched: L1Msg receipts keep `effectiveGasPrice = baseFee`, matching morph-geth's receipt contract (computed via `Transaction::effective_gas_price`, not `gas_price`).

This is a follow-up to #115, which added `nonce/v/r/s/yParity` placeholders but didn't cover `gasPrice`.

## Test plan
- [x] `cargo nextest run -p morph-primitives` (91/91 pass, including updated `test_l1_envelope_rpc_json_includes_geth_parity_fields` and `test_l1_transaction_json_includes_geth_parity_fields`)
- [x] `cargo nextest run -p morph-rpc` (70/70 pass; `from_consensus_tx_l1_message` now asserts a single `"gasPrice":"0x0"` even when the surrounding block carries a non-zero baseFee)
- [x] `cargo clippy -p morph-primitives -p morph-rpc --all-targets -- -D warnings`
- [x] `cargo check --workspace`
- [ ] Manual verification on staging: `rpc \$B eth_getTransactionByHash \"[\\\"0x9b12fcad...\\\"]\" | jq .result.gasPrice` → expect `0x0`

## Related
- Closes the gap left by #115 (nonce/v/r/s placeholders).
- Original divergence noted in the morph-geth ↔ morph-reth RPC parity audit, item #28.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Layer 1 message transactions now correctly include and display a gas price field showing 0x0 in all JSON serialization and RPC responses. This ensures proper compatibility with downstream transaction processing tools and services while maintaining consistency with established serialization standards and protocol specifications expected by clients and utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->