### PR TITLE
chore(deps): bump tar to 0.4.46 (GHSA-3pv8-6f4r-ffg2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,7 +2809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9650,7 +9650,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9730,7 +9730,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10418,9 +10418,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -10437,7 +10437,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11556,7 +11556,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `tar` from 0.4.45 → 0.4.46 to resolve [Dependabot alert #23](https://github.com/morph-l2/morph-reth/security/dependabot/23) (GHSA-3pv8-6f4r-ffg2: PAX header desynchronization, medium severity).
- Lockfile-only change. The `windows-sys` minor bumps are auto-resolved by Cargo as a side effect.

## Other open alerts (not addressed here)
The remaining three alerts cannot be fixed without upstream changes:

| Alert | Package | Reason |
|---|---|---|
| #1 | tracing-subscriber 0.2.25 | Transitive dep of `ark-relations 0.5.1`; upstream advisory only patches 0.3.x — no 0.2.x fix exists. |
| #21 | hickory-proto 0.25.2 | No patched version published yet. Pinned by `reth-dns-discovery`'s `hickory-resolver = "^0.25"` constraint via reth v2.2.0. |
| #22 | hickory-proto 0.25.2 | Patch is in 0.26.1, but reth v2.2.0 pins `^0.25`. Requires reth upgrade or fork patch. |

## Test plan
- [ ] CI green (workspace build, clippy, tests)
- [ ] Dependabot alert #23 closes after merge