### PR TITLE
fix(txpool): enforce Morph transaction admission gates

### DIFF
--- a/crates/consensus/src/validation.rs
+++ b/crates/consensus/src/validation.rs
@@ -303,12 +303,15 @@ impl Consensus<Block> for MorphConsensus {
             ));
         }
 
-        // Validate MorphTx version and field constraints.
+        // Validate MorphTx activation, version and field constraints.
         // Matches go-ethereum's BlockValidator.ValidateBody() → ValidateMorphTxVersion().
+        let is_emerald = self
+            .chain_spec
+            .is_emerald_active_at_timestamp(block.header().timestamp());
         let is_jade = self
             .chain_spec
             .is_jade_active_at_timestamp(block.header().timestamp());
-        validate_morph_txs(&block.body().transactions, is_jade)?;
+        validate_morph_txs(&block.body().transactions, is_emerald, is_jade)?;
 
         // Validate L1 messages ordering and internal consistency with header.
         // This is the body-level half of L1 validation; it verifies that the L1
@@ -579,18 +582,30 @@ fn validate_l1_messages_in_block(
 
 /// Validates all MorphTx (0x7F) transactions in a block.
 ///
-/// Performs two checks per MorphTx:
-/// 1. **Hardfork gate**: rejects V1 transactions before the Jade fork is active
-/// 2. **Field validation**: delegates to [`TxMorph::validate()`] for version-specific
+/// Performs three checks per MorphTx:
+/// 1. **Type hardfork gate**: rejects MorphTx before the Emerald fork is active
+/// 2. **Version hardfork gate**: rejects V1 transactions before the Jade fork is active
+/// 3. **Field validation**: delegates to [`TxMorph::validate()`] for version-specific
 ///    field constraints, memo length, and gas price ordering
 ///
 /// See [`TxMorph::validate()`] for the detailed per-version rules.
-fn validate_morph_txs(txs: &[MorphTxEnvelope], is_jade: bool) -> Result<(), ConsensusError> {
+fn validate_morph_txs(
+    txs: &[MorphTxEnvelope],
+    is_emerald: bool,
+    is_jade: bool,
+) -> Result<(), ConsensusError> {
     for tx in txs {
         let morph_tx = match tx {
             MorphTxEnvelope::Morph(signed) => signed.tx(),
             _ => continue,
         };
+
+        // Match geth's signer gate: MorphTx type is not supported before Emerald.
+        if !is_emerald {
+            return Err(ConsensusError::other(MorphConsensusError::InvalidBody(
+                "MorphTx type is not yet active (emerald fork not reached)".into(),
+            )));
+        }
 
         // Reject MorphTx V1 before Jade fork (hardfork-gated, consensus-only check).
         if !is_jade && morph_tx.version == MORPH_TX_VERSION_1 {
@@ -1658,7 +1673,7 @@ mod tests {
     fn test_validate_morph_tx_v0_valid() {
         // V0 with fee_token_id > 0 and no reference/memo
         let txs = [create_morph_tx_v0(1)];
-        let result = validate_morph_txs(&txs, false);
+        let result = validate_morph_txs(&txs, true, false);
         assert!(result.is_ok());
     }
 
@@ -1666,7 +1681,7 @@ mod tests {
     fn test_validate_morph_tx_v0_zero_fee_token_rejected() {
         // V0 with fee_token_id == 0 should be rejected
         let txs = [create_morph_tx_v0(0)];
-        let result = validate_morph_txs(&txs, false);
+        let result = validate_morph_txs(&txs, true, false);
         assert!(result.is_err());
         assert!(
             result
@@ -1704,7 +1719,7 @@ mod tests {
         ));
 
         let txs = [envelope];
-        let result = validate_morph_txs(&txs, false);
+        let result = validate_morph_txs(&txs, true, false);
         assert!(result.is_err());
         assert!(
             result
@@ -1718,7 +1733,7 @@ mod tests {
     fn test_validate_morph_tx_v1_before_jade_rejected() {
         // V1 before jade fork should be rejected
         let txs = [create_morph_tx_v1(1)];
-        let result = validate_morph_txs(&txs, false);
+        let result = validate_morph_txs(&txs, true, false);
         assert!(result.is_err());
         assert!(
             result
@@ -1732,7 +1747,7 @@ mod tests {
     fn test_validate_morph_tx_v1_after_jade_valid() {
         // V1 after jade fork should pass
         let txs = [create_morph_tx_v1(1)];
-        let result = validate_morph_txs(&txs, true);
+        let result = validate_morph_txs(&txs, true, true);
         assert!(result.is_ok());
     }
 
@@ -1744,6 +1759,46 @@ mod tests {
         let result = consensus.validate_block_pre_execution(&block);
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_block_pre_execution_rejects_morph_tx_before_emerald() {
+        let genesis_json = serde_json::json!({
+            "config": {
+                "chainId": 1337,
+                "homesteadBlock": 0,
+                "eip150Block": 0,
+                "eip155Block": 0,
+                "eip158Block": 0,
+                "byzantiumBlock": 0,
+                "constantinopleBlock": 0,
+                "petersburgBlock": 0,
+                "istanbulBlock": 0,
+                "berlinBlock": 0,
+                "londonBlock": 0,
+                "bernoulliBlock": 0,
+                "curieBlock": 0,
+                "morph203Time": 0,
+                "viridianTime": 0,
+                "emeraldTime": 1000,
+                "jadeForkTime": 2000,
+                "morph": {}
+            },
+            "alloc": {}
+        });
+        let genesis: Genesis = serde_json::from_value(genesis_json).unwrap();
+        let consensus = MorphConsensus::new(Arc::new(MorphChainSpec::from(genesis)));
+        let block = create_sealed_block(999, vec![create_morph_tx_v0(1)]);
+
+        let result = consensus.validate_block_pre_execution(&block);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("emerald fork not reached")
+        );
     }
 
     #[test]
@@ -1775,7 +1830,7 @@ mod tests {
         ));
 
         let txs = [envelope];
-        let result = validate_morph_txs(&txs, true);
+        let result = validate_morph_txs(&txs, true, true);
         assert!(result.is_err());
         assert!(
             result
@@ -1813,7 +1868,7 @@ mod tests {
         ));
 
         let txs = [envelope];
-        let result = validate_morph_txs(&txs, true);
+        let result = validate_morph_txs(&txs, true, true);
         assert!(result.is_err());
         assert!(
             result
@@ -1851,7 +1906,7 @@ mod tests {
         ));
 
         let txs = [envelope];
-        let result = validate_morph_txs(&txs, true);
+        let result = validate_morph_txs(&txs, true, true);
         assert!(result.is_err());
         assert!(
             result
@@ -1865,7 +1920,7 @@ mod tests {
     fn test_validate_morph_txs_skips_non_morph_tx() {
         // Regular transactions should be skipped entirely
         let txs = [create_regular_tx(), create_l1_msg_tx(0)];
-        let result = validate_morph_txs(&txs, false);
+        let result = validate_morph_txs(&txs, false, false);
         assert!(result.is_ok());
     }
 
@@ -1877,7 +1932,7 @@ mod tests {
             create_regular_tx(),
             create_morph_tx_v0(1),
         ];
-        let result = validate_morph_txs(&txs, false);
+        let result = validate_morph_txs(&txs, true, false);
         assert!(result.is_ok());
     }
 

--- a/crates/txpool/src/validator.rs
+++ b/crates/txpool/src/validator.rs
@@ -3,11 +3,20 @@
 //! This module provides Morph-specific transaction validation that extends the standard
 //! Ethereum transaction validation with L2 checks:
 //! - Rejection of EIP-4844 blob transactions
+//! - EIP-3860 max initcode size enforcement
 //! - Rejection of L1 message transactions from the pool
 //! - L1 data fee validation
 //! - MorphTx (0x7F) ERC20 token balance validation
 
 use crate::MorphTxError;
+
+/// EIP-3860 max initcode size: `2 * MAX_CODE_SIZE = 2 * 24 576 = 49 152` bytes.
+///
+/// This is enforced unconditionally at the txpool layer because Morph has been
+/// post-Shanghai since genesis. See `validate_one_with_state` for the rationale
+/// behind not relying on reth's Shanghai-gated check.
+const MAX_INITCODE_SIZE: usize = 49_152;
+
 use alloy_consensus::{BlockHeader, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_primitives::{Address, U256};
@@ -270,6 +279,24 @@ where
                 transaction,
                 InvalidTransactionError::Eip4844Disabled.into(),
             );
+        }
+
+        // EIP-3860: enforce max initcode size on contract-creation transactions.
+        //
+        // Morph has been post-Shanghai since genesis (morph-geth's
+        // `shanghaiBlock = 0` / `IsShanghai(num)`), so this check must always
+        // fire. We can't reuse reth's `EthTransactionValidator` Shanghai gating
+        // because morph-mainnet/hoodi genesis uses the non-standard
+        // `shanghaiBlock` field (inherited from scroll-tech), which alloy's
+        // `Genesis` parser ignores in favour of `shanghaiTime`. Force-activating
+        // Shanghai/Cancun in the chainspec would also flip
+        // `is_shanghai_active_at_timestamp` for `EthStorage::read_block_bodies`,
+        // making body.withdrawals leak into RPC responses and diverging from
+        // morph-geth, which has no withdrawals slot. Enforcing the bound here
+        // keeps the chainspec untouched and the RPC output bit-identical to
+        // morph-geth.
+        if let Err(err) = transaction.ensure_max_init_code_size(MAX_INITCODE_SIZE) {
+            return TransactionValidationOutcome::Invalid(transaction, err);
         }
 
         // Reject L1 message transactions - only included by sequencer
@@ -742,6 +769,109 @@ mod tests {
             TransactionValidationOutcome::Error(_, err) => {
                 panic!("Expected valid transaction, got error: {err:?}");
             }
+        }
+    }
+
+    /// EIP-3860 mempool admission: contract creation transactions whose initcode
+    /// exceeds 49 152 bytes must be rejected. This used to slip through because
+    /// morph-mainnet/hoodi genesis use the non-standard `shanghaiBlock` field
+    /// (inherited from scroll-tech go-ethereum) that alloy's `Genesis` parser
+    /// ignores, leaving Shanghai un-registered in the hardforks table and
+    /// `is_shanghai_active_at_timestamp` permanently `false`. The chainspec
+    /// now force-activates Shanghai/Cancun at `Timestamp(0)` so reth's
+    /// `EthTransactionValidator` triggers the EIP-3860 size check.
+    #[test]
+    fn validate_rejects_oversized_initcode() {
+        let client = new_mock_provider();
+        let signer = address!("0000000000000000000000000000000000000001");
+        client.add_account(signer, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
+        let morph_evm_config = MorphEvmConfig::new_with_default_factory(MORPH_MAINNET.clone());
+
+        // Note: do NOT call `.no_shanghai()` here. The whole point is to verify
+        // that the chainspec correctly activates Shanghai so the inner
+        // `EthTransactionValidator` enforces EIP-3860.
+        let eth_validator: EthTransactionValidator<
+            _,
+            crate::MorphPooledTransaction,
+            MorphEvmConfig,
+        > = EthTransactionValidatorBuilder::new(client, morph_evm_config)
+            .disable_balance_check()
+            .build::<crate::MorphPooledTransaction, _>(InMemoryBlobStore::default());
+        let validator = MorphTransactionValidator::new(eth_validator);
+
+        let oversize_initcode = vec![0u8; MAX_INITCODE_SIZE + 1];
+        let tx = TxLegacy {
+            chain_id: Some(2818),
+            nonce: 0,
+            gas_limit: 30_000_000,
+            to: TxKind::Create,
+            value: U256::ZERO,
+            input: oversize_initcode.into(),
+            gas_price: 2_000_000_000,
+        };
+        let signed_tx = Signed::new_unchecked(tx, Signature::test_signature(), B256::ZERO);
+        let envelope = MorphTxEnvelope::Legacy(signed_tx);
+        let recovered = Recovered::new_unchecked(envelope, signer);
+        let len = recovered.encode_2718_len();
+        let pooled_tx = crate::MorphPooledTransaction::new(recovered, len);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, pooled_tx);
+
+        match outcome {
+            TransactionValidationOutcome::Invalid(_, err) => {
+                let msg = err.to_string();
+                assert!(
+                    msg.contains("max_init_code_size") || msg.contains("init code size"),
+                    "expected EIP-3860 rejection, got: {msg}"
+                );
+            }
+            other => panic!("expected oversized initcode to be rejected, got: {other:?}"),
+        }
+    }
+
+    /// Counterpart to `validate_rejects_oversized_initcode`: an initcode
+    /// exactly at the EIP-3860 limit (49 152 bytes) must still be admitted.
+    #[test]
+    fn validate_accepts_initcode_at_limit() {
+        let client = new_mock_provider();
+        let signer = address!("0000000000000000000000000000000000000001");
+        client.add_account(signer, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
+        let morph_evm_config = MorphEvmConfig::new_with_default_factory(MORPH_MAINNET.clone());
+        let eth_validator: EthTransactionValidator<
+            _,
+            crate::MorphPooledTransaction,
+            MorphEvmConfig,
+        > = EthTransactionValidatorBuilder::new(client, morph_evm_config)
+            .disable_balance_check()
+            .build::<crate::MorphPooledTransaction, _>(InMemoryBlobStore::default());
+        let validator = MorphTransactionValidator::new(eth_validator);
+
+        let initcode_at_limit = vec![0u8; MAX_INITCODE_SIZE];
+        let tx = TxLegacy {
+            chain_id: Some(2818),
+            nonce: 0,
+            gas_limit: 30_000_000,
+            to: TxKind::Create,
+            value: U256::ZERO,
+            input: initcode_at_limit.into(),
+            gas_price: 2_000_000_000,
+        };
+        let signed_tx = Signed::new_unchecked(tx, Signature::test_signature(), B256::ZERO);
+        let envelope = MorphTxEnvelope::Legacy(signed_tx);
+        let recovered = Recovered::new_unchecked(envelope, signer);
+        let len = recovered.encode_2718_len();
+        let pooled_tx = crate::MorphPooledTransaction::new(recovered, len);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, pooled_tx);
+        // The validator may still reject this because of intrinsic gas or
+        // balance checks downstream; the only thing this test asserts is that
+        // EIP-3860 itself does NOT fire at exactly the limit.
+        if let TransactionValidationOutcome::Invalid(_, err) = &outcome {
+            let msg = err.to_string();
+            assert!(
+                !msg.contains("max_init_code_size") && !msg.contains("init code size"),
+                "EIP-3860 must not reject initcode of exactly the size limit; got: {msg}"
+            );
         }
     }
 

--- a/crates/txpool/src/validator.rs
+++ b/crates/txpool/src/validator.rs
@@ -9,14 +9,6 @@
 //! - MorphTx (0x7F) ERC20 token balance validation
 
 use crate::MorphTxError;
-
-/// EIP-3860 max initcode size: `2 * MAX_CODE_SIZE = 2 * 24 576 = 49 152` bytes.
-///
-/// This is enforced unconditionally at the txpool layer because Morph has been
-/// post-Shanghai since genesis. See `validate_one_with_state` for the rationale
-/// behind not relying on reth's Shanghai-gated check.
-const MAX_INITCODE_SIZE: usize = 49_152;
-
 use alloy_consensus::{BlockHeader, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_primitives::{Address, U256};
@@ -39,6 +31,15 @@ use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},
 };
+
+/// EIP-3860 max initcode size (`2 * MAX_CODE_SIZE = 2 * 24 576 = 49 152` bytes).
+///
+/// Reuses revm's canonical constant — the same `eip3860::MAX_INITCODE_SIZE` that
+/// reth's `EthTransactionValidator` uses — so it stays pinned to the EIP-170
+/// code-size base instead of a hand-copied literal. Enforced unconditionally at
+/// the txpool layer because Morph has been post-Shanghai since genesis; see
+/// `validate_one_with_state` for why we can't rely on reth's Shanghai-gated check.
+const MAX_INITCODE_SIZE: usize = reth_revm::revm::primitives::eip3860::MAX_INITCODE_SIZE;
 
 /// Tracks L1 block info for the current chain head.
 ///
@@ -281,24 +282,6 @@ where
             );
         }
 
-        // EIP-3860: enforce max initcode size on contract-creation transactions.
-        //
-        // Morph has been post-Shanghai since genesis (morph-geth's
-        // `shanghaiBlock = 0` / `IsShanghai(num)`), so this check must always
-        // fire. We can't reuse reth's `EthTransactionValidator` Shanghai gating
-        // because morph-mainnet/hoodi genesis uses the non-standard
-        // `shanghaiBlock` field (inherited from scroll-tech), which alloy's
-        // `Genesis` parser ignores in favour of `shanghaiTime`. Force-activating
-        // Shanghai/Cancun in the chainspec would also flip
-        // `is_shanghai_active_at_timestamp` for `EthStorage::read_block_bodies`,
-        // making body.withdrawals leak into RPC responses and diverging from
-        // morph-geth, which has no withdrawals slot. Enforcing the bound here
-        // keeps the chainspec untouched and the RPC output bit-identical to
-        // morph-geth.
-        if let Err(err) = transaction.ensure_max_init_code_size(MAX_INITCODE_SIZE) {
-            return TransactionValidationOutcome::Invalid(transaction, err);
-        }
-
         // Reject L1 message transactions - only included by sequencer
         if is_l1_message(&transaction) {
             return TransactionValidationOutcome::Invalid(
@@ -333,6 +316,29 @@ where
                 transaction,
                 InvalidTransactionError::TxTypeNotSupported.into(),
             );
+        }
+
+        // EIP-3860: enforce max initcode size on contract-creation transactions.
+        //
+        // Morph has been post-Shanghai since genesis (morph-geth's
+        // `shanghaiBlock = 0` / `IsShanghai(num)`), so this check must always
+        // fire. We can't reuse reth's `EthTransactionValidator` Shanghai gating
+        // because morph-mainnet/hoodi genesis uses the non-standard
+        // `shanghaiBlock` field (inherited from scroll-tech), which alloy's
+        // `Genesis` parser ignores in favour of `shanghaiTime`. Force-activating
+        // Shanghai/Cancun in the chainspec would also flip
+        // `is_shanghai_active_at_timestamp` for `EthStorage::read_block_bodies`,
+        // making body.withdrawals leak into RPC responses and diverging from
+        // morph-geth, which has no withdrawals slot. Enforcing the bound here
+        // keeps the chainspec untouched and the RPC output bit-identical to
+        // morph-geth.
+        //
+        // Placed after the L1-message / EIP-7702 / MorphTx type gates so a
+        // transaction rejected purely on its type still surfaces that type error
+        // (matching morph-geth), and before the inner validator so we skip its
+        // state lookups for oversized payloads.
+        if let Err(err) = transaction.ensure_max_init_code_size(MAX_INITCODE_SIZE) {
+            return TransactionValidationOutcome::Invalid(transaction, err);
         }
 
         let outcome = self
@@ -777,9 +783,11 @@ mod tests {
     /// morph-mainnet/hoodi genesis use the non-standard `shanghaiBlock` field
     /// (inherited from scroll-tech go-ethereum) that alloy's `Genesis` parser
     /// ignores, leaving Shanghai un-registered in the hardforks table and
-    /// `is_shanghai_active_at_timestamp` permanently `false`. The chainspec
-    /// now force-activates Shanghai/Cancun at `Timestamp(0)` so reth's
-    /// `EthTransactionValidator` triggers the EIP-3860 size check.
+    /// `is_shanghai_active_at_timestamp` permanently `false` — which means reth's
+    /// Shanghai-gated EIP-3860 check (`EthTransactionValidator`, `eth.rs:468`) is
+    /// always skipped. The rejection is therefore enforced unconditionally by
+    /// `MorphTransactionValidator` itself (see `validate_one_with_state`), not by
+    /// the chainspec or the inner reth validator.
     #[test]
     fn validate_rejects_oversized_initcode() {
         let client = new_mock_provider();
@@ -787,9 +795,10 @@ mod tests {
         client.add_account(signer, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
         let morph_evm_config = MorphEvmConfig::new_with_default_factory(MORPH_MAINNET.clone());
 
-        // Note: do NOT call `.no_shanghai()` here. The whole point is to verify
-        // that the chainspec correctly activates Shanghai so the inner
-        // `EthTransactionValidator` enforces EIP-3860.
+        // Built from the real `MORPH_MAINNET` chainspec, under which Shanghai is
+        // never active, so the inner `EthTransactionValidator` does not enforce
+        // EIP-3860. This test verifies that `MorphTransactionValidator` rejects
+        // the oversized initcode on its own.
         let eth_validator: EthTransactionValidator<
             _,
             crate::MorphPooledTransaction,


### PR DESCRIPTION
Closes #121

## Summary
- Reject contract-creation transactions whose initcode exceeds the EIP-3860 limit at the Morph txpool layer, matching morph-geth admission behavior.
- Reject MorphTx (`0x7F`) bodies before the Emerald fork during consensus pre-execution validation, matching morph-geth's signer/type gate.

## Details
Morph mainnet and hoodi genesis use morph-geth's non-standard `shanghaiBlock` field. alloy's `Genesis` parser does not convert that into an upstream `shanghaiTime`, so reth's default txpool validator can miss the EIP-3860 initcode size guard. The fix keeps the chainspec untouched and enforces the Morph-specific bound in `MorphTransactionValidator`.

This PR also closes a related hardfork gate gap: txpool already rejected MorphTx before Emerald, but block import only enforced MorphTx V1 before Jade. Consensus validation now rejects any MorphTx before Emerald so imported payloads align with morph-geth.

## Test plan
- `cargo fmt --all -- --check`
- `cargo test -p morph-consensus`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced EIP-3860 initcode size limit (49,152 bytes), preventing oversized contract-creation transactions.
  * Transaction acceptance now respects fork activation: certain transaction types are rejected until the relevant network upgrades are active.

* **Tests**
  * Added tests verifying initcode limit behavior and fork-gated transaction validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->