### PR TITLE
chore: lower workspace Rust version to 1.93

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.3.0"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 publish = false
 


### PR DESCRIPTION
## Summary
- Lower the workspace `rust-version` from `1.95` to `1.93` so prover environments using Rust 1.93 are not blocked by the manifest MSRV gate.

## Test plan
- cargo metadata --no-deps --format-version 1

## Notes
- Full compilation with Rust 1.93 was not run locally because the 1.93 toolchain is not installed on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Rust version requirement to improve compatibility with a broader range of development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->