### PR TITLE
chore(engine-api): remove per-block debug timing logs

### DIFF
--- a/crates/engine-api/src/builder.rs
+++ b/crates/engine-api/src/builder.rs
@@ -288,7 +288,6 @@ where
         }
 
         // 2. Convert and forward to reth engine tree (`newPayload` path).
-        let convert_started = Instant::now();
         let (payload, _) = match self.execution_payload_from_executable_data(&data) {
             Ok(v) => v,
             Err(err) => {
@@ -305,9 +304,7 @@ where
                 return Ok(GenericResponse { success: false });
             }
         };
-        let convert_elapsed = convert_started.elapsed();
 
-        let new_payload_started = Instant::now();
         let status = match self.engine_handle.new_payload(payload).await {
             Ok(status) => status,
             Err(err) => {
@@ -324,7 +321,6 @@ where
                 return Ok(GenericResponse { success: false });
             }
         };
-        let new_payload_elapsed = new_payload_started.elapsed();
 
         tracing::debug!(
             target: "morph::engine",
@@ -334,18 +330,6 @@ where
         );
 
         let success = payload_status_is_validated(&status);
-        tracing::info!(
-            target: "morph::engine",
-            block_number = data.number,
-            block_hash = %data.hash,
-            convert_elapsed = ?convert_elapsed,
-            new_payload_elapsed = ?new_payload_elapsed,
-            total_elapsed = ?validate_started.elapsed(),
-            status = ?status.status,
-            success,
-            "validate_l2_block timing"
-        );
-
         self.metrics
             .validate_l2_block_duration_seconds
             .record(validate_started.elapsed());
@@ -832,18 +816,13 @@ impl<Provider> RealMorphL2EngineApi<Provider> {
             + BlockNumReader
             + CanonChainTracker<Header = MorphHeader>,
     {
-        let import_started = Instant::now();
-        let convert_started = Instant::now();
         let (payload, header) = self.execution_payload_from_executable_data(&data)?;
-        let convert_elapsed = convert_started.elapsed();
 
-        let new_payload_started = Instant::now();
         let payload_status = self
             .engine_handle
             .new_payload(payload)
             .await
             .map_err(|e| MorphEngineApiError::ExecutionFailed(e.to_string()))?;
-        let new_payload_elapsed = new_payload_started.elapsed();
         ensure_payload_status_valid(&payload_status, "newPayload")?;
 
         // The safe/finalized hashes passed here serve two purposes in reth's engine
@@ -885,27 +864,12 @@ impl<Provider> RealMorphL2EngineApi<Provider> {
 
         self.provider.on_forkchoice_update_received(&forkchoice);
 
-        let fcu_started = Instant::now();
         let fcu_result = self
             .engine_handle
             .fork_choice_updated(forkchoice, None)
             .await
             .map_err(|e| MorphEngineApiError::ExecutionFailed(e.to_string()))?;
-        let fcu_elapsed = fcu_started.elapsed();
         ensure_payload_status_valid(&fcu_result.payload_status, "forkchoiceUpdated")?;
-
-        tracing::info!(
-            target: "morph::engine",
-            block_number = data.number,
-            block_hash = %data.hash,
-            convert_elapsed = ?convert_elapsed,
-            new_payload_elapsed = ?new_payload_elapsed,
-            fcu_elapsed = ?fcu_elapsed,
-            total_elapsed = ?import_started.elapsed(),
-            new_payload_status = ?payload_status.status,
-            fcu_status = ?fcu_result.payload_status.status,
-            "new_l2_block engine timing"
-        );
 
         Ok(header)
     }


### PR DESCRIPTION
## Summary

- Remove the `new_l2_block engine timing` and `validate_l2_block timing` info logs in `morph-engine-api`, which fired once per imported block and flooded stdout during live sync (the node imports a block roughly every second).
- These logs were added during early debugging; per-block durations are already covered by the `new_l2_block_duration_seconds` and `validate_l2_block_duration_seconds` Prometheus metrics, and block import status is still visible via reth's own `Block added to canonical chain` log.
- Also drop the `Instant` timing variables that only existed to feed these logs.

## Test plan

- [x] `cargo check -p morph-engine-api -p morph-reth`
- [x] `cargo clippy -p morph-engine-api --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal instrumentation for block validation operations by removing detailed timing logs while preserving core validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->