### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4872,7 +4872,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "morph-chainspec"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "morph-consensus"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "morph-engine-api"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "morph-engine-tree-ext"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "morph-evm"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "morph-node"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "morph-payload-builder"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5110,7 +5110,7 @@ dependencies = [
 
 [[package]]
 name = "morph-payload-types"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "morph-primitives"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "morph-reference-index"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "morph-reth"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "morph-revm"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5219,7 +5219,7 @@ dependencies = [
 
 [[package]]
 name = "morph-rpc"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "morph-statetest"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "morph-txpool"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT OR Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,9 @@ ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2026-0119 hickory-proto O(n^2) name compression
     # fixed in hickory-proto 0.26.1, but hickory-resolver ^0.25 cannot select it
     "RUSTSEC-2026-0119",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
+    # build-time proc-macro pulled transitively via alloy-sol-macro; no fix available
+    "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Summary

Prepares the v1.0.0 release. Bumps `[workspace.package].version` from `0.3.0` to `1.0.0` and refreshes `Cargo.lock` so all 15 internal `morph-*` crates (including the new `morph-engine-tree-ext` and `morph-statetest`) carry the new version.

This marks morph-reth's first stable release. Highlights of v0.3.0 → v1.0.0 (20 PRs):

- **feat:** unfork reth to upstream `paradigmxyz/reth v2.2.0` with retroactive state-root trust (#98) — morph-reth is now a Reth SDK extension, not a fork
- **feat:** centralized-sequencer EL support (V2 engine API + reorg + `next_l1_msg_index` hardening) (#124)
- **feat:** standalone `morph-statetest` runner (#113)
- **fix:** align Morph transaction/receipt serialization with morph-geth (#114, #115, #117)
- **fix:** enforce Morph transaction admission gates in txpool (#120)
- **fix:** preserve finalized tags during safe imports (#130) and exact L1 fee fallback encoding (#131)
- **fix:** treat zero withdraw trie root as unspecified (#127)
- **fix:** address audit follow-ups (#116)
- **chore(deps):** lower workspace Rust version to 1.93 (#129); bump `tar` to 0.4.46 for GHSA-3pv8-6f4r-ffg2 (#119)
- **chore:** Grafana dashboard signal quality improvements (#110); remove per-block debug timing logs (#132)

A 1.0.0 bump is appropriate: the unfork (#98) and centralized-sequencer support (#124) together with the audit fixes (#116) make this our first API/protocol-stable release.

## Test plan

- [ ] CI green on this PR (build + clippy + cargo-deny + tests)
- [ ] After merge, tag `v1.0.0` on `main` and push to `origin` (GitHub release CI) and `gitlab`
- [ ] Push `release/1.0.0` branch to `gitlab` for deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the workspace package version to **1.0.0**, marking the first stable release.
* **Chores**
  * Updated security advisory ignore settings to suppress an additional RustSec warning for a build-time proc-macro dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->