### PR TITLE
fix(local-test): pass Hoodi network flag to morphnode

### DIFF
--- a/local-test/README.md
+++ b/local-test/README.md
@@ -67,7 +67,8 @@ All defaults can be overridden via environment variables. Common ones:
 | `MORPHNODE_BIN` | `../morph/node/build/bin/morphnode` | Path to morphnode binary |
 | `RETH_HTTP_PORT` | `8545` | HTTP RPC port |
 | `RETH_AUTHRPC_PORT` | `8551` | Engine API auth RPC port |
-| `MORPH_NODE_L1_RPC` | *(per-network default)* | L1 Ethereum RPC endpoint |
+| `MORPH_NODE_L1_RPC` | *(per-network default)* | L1 Ethereum execution RPC endpoint |
+| `MORPH_NODE_L1_BEACON_RPC` | *(per-network default)* | L1 Ethereum beacon (blob) RPC endpoint — required for L1 derivation |
 
 Example with overrides:
 

--- a/local-test/common.sh
+++ b/local-test/common.sh
@@ -40,7 +40,7 @@ else
   : "${MORPH_NODE_L1_BEACON_RPC:=${MORPH_NODE_L1_ETH_BEACON_RPC:-https://ethereum-hoodi-beacon-api.publicnode.com}}"
   : "${MORPH_NODE_DEPOSIT_CONTRACT:=${MORPH_NODE_SYNC_DEPOSIT_CONTRACT_ADDRESS:-0xd7f39d837f4790b215ba67e0ab63665912648dbe}}"
   : "${MORPH_NODE_ROLLUP_CONTRACT:=0x57e0e6dde89dc52c01fe785774271504b1e04664}"
-  : "${MORPH_NODE_EXTRA_FLAGS:=}"
+  : "${MORPH_NODE_EXTRA_FLAGS:=--hoodi}"
   : "${CONFIG_ZIP_URL:=https://raw.githubusercontent.com/morph-l2/run-morph-node/main/hoodi/data.zip}"
   : "${CONFIG_ZIP_PATH:=./local-test/hoodi-data.zip}"
   : "${MORPH_CHAIN:=hoodi}"

--- a/local-test/common.sh
+++ b/local-test/common.sh
@@ -25,6 +25,9 @@ export MORPH_NETWORK
 
 if [[ "${MORPH_NETWORK}" == "mainnet" ]]; then
   : "${MORPH_NODE_L1_RPC:=${MORPH_NODE_L1_ETH_RPC:-https://ethereum.publicnode.com}}"
+  # L1 Beacon (CL) endpoint — a fullnode (no sequencer signer) derives L2 blocks
+  # from batches posted to L1 as EIP-4844 blobs, so the beacon blob API is required.
+  : "${MORPH_NODE_L1_BEACON_RPC:=${MORPH_NODE_L1_ETH_BEACON_RPC:-https://ethereum-beacon-api.publicnode.com}}"
   : "${MORPH_NODE_DEPOSIT_CONTRACT:=${MORPH_NODE_SYNC_DEPOSIT_CONTRACT_ADDRESS:-0x3931ade842f5bb8763164bdd81e5361dce6cc1ef}}"
   : "${MORPH_NODE_ROLLUP_CONTRACT:=}"
   : "${MORPH_NODE_EXTRA_FLAGS:=--mainnet}"
@@ -33,6 +36,8 @@ if [[ "${MORPH_NETWORK}" == "mainnet" ]]; then
   : "${MORPH_CHAIN:=mainnet}"
 else
   : "${MORPH_NODE_L1_RPC:=${MORPH_NODE_L1_ETH_RPC:-https://ethereum-hoodi-rpc.publicnode.com}}"
+  # L1 Beacon (CL) endpoint — see mainnet branch above for why this is required.
+  : "${MORPH_NODE_L1_BEACON_RPC:=${MORPH_NODE_L1_ETH_BEACON_RPC:-https://ethereum-hoodi-beacon-api.publicnode.com}}"
   : "${MORPH_NODE_DEPOSIT_CONTRACT:=${MORPH_NODE_SYNC_DEPOSIT_CONTRACT_ADDRESS:-0xd7f39d837f4790b215ba67e0ab63665912648dbe}}"
   : "${MORPH_NODE_ROLLUP_CONTRACT:=0x57e0e6dde89dc52c01fe785774271504b1e04664}"
   : "${MORPH_NODE_EXTRA_FLAGS:=}"

--- a/local-test/node-start.sh
+++ b/local-test/node-start.sh
@@ -29,6 +29,7 @@ args=(
   --l2.eth "http://${RETH_HTTP_ADDR}:${RETH_HTTP_PORT}"
   --l2.engine "http://${RETH_AUTHRPC_ADDR}:${RETH_AUTHRPC_PORT}"
   --l1.rpc "${MORPH_NODE_L1_RPC}"
+  --l1.beaconrpc "${MORPH_NODE_L1_BEACON_RPC}"
   --sync.depositContractAddr "${MORPH_NODE_DEPOSIT_CONTRACT}"
   --log.filename "${NODE_LOG_FILE}"
 )


### PR DESCRIPTION
## Summary
- pass `--hoodi` to morphnode when using `local-test` Hoodi scripts

## Root cause
The Hoodi branch configured the Hoodi RPCs and contract addresses, but did not pass the Hoodi network flag to morphnode. morphnode then started with dev network defaults and failed because no L1 sequencer contract was configured.

## Validation
- `bash -n local-test/common.sh local-test/node-start.sh local-test/start-all.sh`
- confirmed the running PM2 morph-node args include `--hoodi` with `restarts=0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an L1 beacon RPC endpoint in local test environments.
  * Local startup now includes the beacon RPC setting when launching the node.

* **Documentation**
  * Updated the local test README to describe the new required environment variable and clarify the L1 RPC setting.

* **Bug Fixes**
  * Improved network-specific defaults for supported test networks, including hoodi, to better match required configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->