### PR TITLE
perf(reference-index): bound reorg to finalized, simplify read gate, bounded RPC wait (#143 #144 #145)

### DIFF
--- a/crates/reference-index/src/backfill.rs
+++ b/crates/reference-index/src/backfill.rs
@@ -4,7 +4,9 @@ use crate::{
     db::ReferenceIndexDb,
     source::{CanonicalBlock, CanonicalChain},
     types::ReferenceIndexError,
-    writer::{set_jade_first_block_number, update_indexed_to, write_block},
+    writer::{
+        prune_indexed_blocks_before, set_jade_first_block_number, update_indexed_to, write_block,
+    },
 };
 use reth_db_api::transaction::DbTx;
 
@@ -38,11 +40,18 @@ pub(crate) fn resolve_jade_first_block<C: CanonicalChain>(
 }
 
 /// Commit one already-validated contiguous canonical block batch.
+///
+/// `finalized` is the L1 finalized canonical block number, if any. Because a
+/// finalized block can never be reorged, `IndexedBlocks` breadcrumbs strictly
+/// below it are never needed for reorg rewind again and are pruned here — but
+/// only once the cursor tip has reached the pruning floor, so a deep backfill
+/// that is still below finalized keeps its rows (and the tip's row) intact.
 pub(crate) fn commit_canonical_batch(
     db: &ReferenceIndexDb,
     jade_first_block: u64,
     expected_start: u64,
     blocks: &[CanonicalBlock],
+    finalized: Option<u64>,
 ) -> Result<u64, ReferenceIndexError> {
     let Some(last) = blocks.last() else {
         return Ok(0);
@@ -71,6 +80,15 @@ pub(crate) fn commit_canonical_batch(
     }
     set_jade_first_block_number(&tx, jade_first_block)?;
     update_indexed_to(&tx, last.number)?;
+    // Prune reorg breadcrumbs below finalized, but never above the cursor tip:
+    // during a deep backfill still below finalized the floor is skipped so the
+    // tip's own breadcrumb (and everything reconcile may still need) survives.
+    if let Some(finalized) = finalized {
+        let floor = finalized.max(jade_first_block);
+        if floor <= last.number {
+            prune_indexed_blocks_before(&tx, floor)?;
+        }
+    }
     tx.commit()?;
     Ok(references_written)
 }

--- a/crates/reference-index/src/backfill.rs
+++ b/crates/reference-index/src/backfill.rs
@@ -92,3 +92,39 @@ pub(crate) fn commit_canonical_batch(
     tx.commit()?;
     Ok(references_written)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    fn block(number: u64) -> CanonicalBlock {
+        let mut hash = [0u8; 32];
+        hash[24..].copy_from_slice(&number.to_be_bytes());
+        CanonicalBlock {
+            number,
+            hash: B256::from(hash),
+            timestamp: number,
+            transactions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn finalized_breadcrumb_pruning_is_bounded_and_resumes_on_the_next_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = ReferenceIndexDb::open(dir.path(), 2818, B256::ZERO).unwrap();
+        let blocks = (0..=600).map(block).collect::<Vec<_>>();
+
+        commit_canonical_batch(&db, 0, 0, &blocks, Some(600)).unwrap();
+
+        assert!(db.indexed_block_hash(511).unwrap().is_none());
+        assert!(db.indexed_block_hash(512).unwrap().is_some());
+        assert!(db.indexed_block_hash(600).unwrap().is_some());
+
+        commit_canonical_batch(&db, 0, 601, &[block(601)], Some(600)).unwrap();
+
+        assert!(db.indexed_block_hash(599).unwrap().is_none());
+        assert!(db.indexed_block_hash(600).unwrap().is_some());
+        assert!(db.indexed_block_hash(601).unwrap().is_some());
+    }
+}

--- a/crates/reference-index/src/metrics.rs
+++ b/crates/reference-index/src/metrics.rs
@@ -30,4 +30,10 @@ pub(crate) struct ReferenceIndexMetrics {
     pub(crate) failures_total: Counter,
     /// Wall-clock duration of a reconciliation turn.
     pub(crate) batch_duration_seconds: Histogram,
+    /// RPC queries that entered the bounded server-side catch-up wait.
+    pub(crate) rpc_waits_total: Counter,
+    /// Bounded RPC waits that timed out and still returned `IndexBehind`.
+    pub(crate) rpc_wait_timeouts_total: Counter,
+    /// Wall-clock duration a query spent in the bounded catch-up wait.
+    pub(crate) rpc_wait_duration_seconds: Histogram,
 }

--- a/crates/reference-index/src/reader.rs
+++ b/crates/reference-index/src/reader.rs
@@ -11,10 +11,16 @@ use parking_lot::RwLock;
 use reth_db_api::{cursor::DbCursorRO, transaction::DbTx};
 use std::sync::{
     Arc,
-    atomic::{AtomicU8, AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicU8, Ordering},
 };
 
-/// Runtime phase that controls whether reference queries can be served.
+/// Runtime phase, exported purely for metrics and logs.
+///
+/// The read path no longer branches on this. Read correctness comes from the
+/// MDBX read-transaction snapshot plus the `(indexed_to, indexed_hash) == tip`
+/// comparison in [`ReferenceIndexHandle::query_at`], and from the before/after
+/// `chain_info()` bracketing in the RPC layer. The only read-gate bit derived
+/// from phase is [`ReferenceIndexShared::unavailable`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ReferenceIndexPhase {
@@ -52,17 +58,24 @@ impl ReferenceIndexPhase {
 #[derive(Debug)]
 struct ReferenceIndexShared {
     db: RwLock<Option<ReferenceIndexDb>>,
+    /// Latest runtime phase. Kept for metrics/logs only; not read on the query
+    /// path (see [`ReferenceIndexPhase`]).
     phase: AtomicU8,
-    /// Even values are stable snapshots; odd values mean a transition is in progress.
-    generation: AtomicU64,
+    /// Set while the runtime is in [`ReferenceIndexPhase::Unavailable`] (manual
+    /// rebuild required / persistent failure). The read path returns
+    /// `IndexUnavailable` so clients stop retrying; in every other phase the
+    /// tip comparison decides on its own (`IndexBehind` when the cursor lags).
+    unavailable: AtomicBool,
     metrics: ReferenceIndexMetrics,
 }
 
 /// Cloneable query handle shared by the runtime and RPC layer.
 ///
-/// The runtime installs the database and advances the phase. Queries only
-/// succeed in [`ReferenceIndexPhase::Live`] when the durable cursor exactly
-/// matches the supplied canonical tip number and hash.
+/// The runtime installs the database and advances the phase. A query succeeds
+/// only when the durable cursor exactly matches the supplied canonical tip
+/// (number and hash) within a single MDBX snapshot; otherwise it is
+/// `IndexBehind`. The `Unavailable` phase is the one runtime state that
+/// short-circuits to `IndexUnavailable`.
 #[derive(Clone, Debug)]
 pub struct ReferenceIndexHandle {
     shared: Arc<ReferenceIndexShared>,
@@ -76,7 +89,7 @@ impl ReferenceIndexHandle {
             shared: Arc::new(ReferenceIndexShared {
                 db: RwLock::new(None),
                 phase: AtomicU8::new(ReferenceIndexPhase::Opening as u8),
-                generation: AtomicU64::new(0),
+                unavailable: AtomicBool::new(false),
                 metrics: ReferenceIndexMetrics::default(),
             }),
             jade_timestamp,
@@ -88,6 +101,16 @@ impl ReferenceIndexHandle {
         ReferenceIndexPhase::from_u8(self.shared.phase.load(Ordering::Acquire))
     }
 
+    /// Whether a canonical tip at `timestamp` predates Jade.
+    ///
+    /// Before Jade no reference-carrying transaction can exist, so the complete
+    /// result is empty. The RPC layer short-circuits on this so pre-Jade
+    /// queries never reach [`Self::query_at`] — a pre-Jade answer is a terminal
+    /// empty result, not `IndexBehind`, and clients must not retry it.
+    pub fn is_pre_jade(&self, timestamp: u64) -> bool {
+        timestamp < self.jade_timestamp
+    }
+
     pub(crate) fn install_db(&self, db: ReferenceIndexDb) {
         *self.shared.db.write() = Some(db);
     }
@@ -96,9 +119,10 @@ impl ReferenceIndexHandle {
         if self.phase() == phase {
             return;
         }
-        self.shared.generation.fetch_add(1, Ordering::AcqRel);
         self.shared.phase.store(phase as u8, Ordering::Release);
-        self.shared.generation.fetch_add(1, Ordering::Release);
+        self.shared
+            .unavailable
+            .store(phase == ReferenceIndexPhase::Unavailable, Ordering::Release);
         self.shared.metrics.phase.set(phase as u8 as f64);
         self.shared
             .metrics
@@ -114,11 +138,6 @@ impl ReferenceIndexHandle {
         &self.shared.metrics
     }
 
-    #[cfg(test)]
-    pub(crate) fn generation(&self) -> u64 {
-        self.shared.generation.load(Ordering::Acquire)
-    }
-
     /// Execute a paginated query at an exact canonical chain snapshot.
     ///
     /// Cursor validation and result iteration share one MDBX read transaction,
@@ -130,39 +149,18 @@ impl ReferenceIndexHandle {
         query: ReferenceQuery,
         canonical_tip: CanonicalTip,
     ) -> Result<Vec<ReferenceTransactionResult>, ReferenceIndexError> {
-        let generation = loop {
-            let generation = self.shared.generation.load(Ordering::Acquire);
-            if generation.is_multiple_of(2) {
-                break generation;
-            }
-            std::hint::spin_loop();
-        };
-        match self.phase() {
-            ReferenceIndexPhase::Opening => return Err(ReferenceIndexError::Initializing),
-            ReferenceIndexPhase::PreJade => {
-                return if canonical_tip.timestamp < self.jade_timestamp {
-                    Ok(Vec::new())
-                } else {
-                    Err(ReferenceIndexError::IndexBehind)
-                };
-            }
-            ReferenceIndexPhase::Deferred | ReferenceIndexPhase::Backfill => {
-                return Err(ReferenceIndexError::IndexBehind);
-            }
-            ReferenceIndexPhase::Repairing | ReferenceIndexPhase::Unavailable => {
-                return Err(ReferenceIndexError::IndexUnavailable);
-            }
-            ReferenceIndexPhase::Live => {}
+        if self.shared.unavailable.load(Ordering::Acquire) {
+            return Err(ReferenceIndexError::IndexUnavailable);
         }
 
-        let db = self.db().ok_or(ReferenceIndexError::IndexUnavailable)?;
+        let db = self.db().ok_or(ReferenceIndexError::Initializing)?;
         let tx = db.tx()?;
         let indexed_to = tx
             .get::<IndexMeta>(IndexMetaKey::IndexedTo.into())?
             .map(decode_u64)
             .transpose()?;
         let Some(indexed_to) = indexed_to else {
-            return Err(ReferenceIndexError::IndexUnavailable);
+            return Err(ReferenceIndexError::IndexBehind);
         };
 
         let indexed_hash = tx
@@ -171,7 +169,7 @@ impl ReferenceIndexHandle {
             })?
             .map(|value| value.0);
         let Some(indexed_hash) = indexed_hash else {
-            return Err(ReferenceIndexError::IndexUnavailable);
+            return Err(ReferenceIndexError::IndexBehind);
         };
         if indexed_to != canonical_tip.number || indexed_hash != canonical_tip.hash {
             return Err(ReferenceIndexError::IndexBehind);
@@ -203,12 +201,6 @@ impl ReferenceIndexHandle {
                 });
             }
             next = cursor.next()?;
-        }
-
-        if self.shared.generation.load(Ordering::Acquire) != generation
-            || self.phase() != ReferenceIndexPhase::Live
-        {
-            return Err(ReferenceIndexError::IndexUnavailable);
         }
 
         Ok(results)
@@ -253,13 +245,30 @@ mod tests {
     }
 
     #[test]
-    fn setting_the_same_phase_does_not_invalidate_readers() {
-        let handle = ReferenceIndexHandle::new(200);
-        let generation = handle.shared.generation.load(Ordering::Acquire);
+    fn unavailable_phase_blocks_reads_and_recovers() {
+        let dir = TempDir::new().unwrap();
+        let db = ReferenceIndexDb::open(dir.path(), 2818, B256::ZERO).unwrap();
+        let tx = db.tx_mut().unwrap();
+        write_block(&tx, 10, B256::repeat_byte(0xaa), 100, &[]).unwrap();
+        update_indexed_to(&tx, 10).unwrap();
+        tx.commit().unwrap();
+        let handle = handle_with_phase(db, 0, ReferenceIndexPhase::Unavailable);
+        let query = ReferenceQuery::new(B256::with_last_byte(1), None, None).unwrap();
+        let tip = CanonicalTip {
+            number: 10,
+            hash: B256::repeat_byte(0xaa),
+            timestamp: 100,
+        };
 
-        handle.set_phase(ReferenceIndexPhase::Opening);
+        // Unavailable short-circuits even when the cursor matches the tip.
+        assert!(matches!(
+            handle.query_at(query, tip),
+            Err(ReferenceIndexError::IndexUnavailable)
+        ));
 
-        assert_eq!(handle.shared.generation.load(Ordering::Acquire), generation);
+        // Recovering out of Unavailable clears the gate; the matching tip serves.
+        handle.set_phase(ReferenceIndexPhase::Live);
+        assert!(handle.query_at(query, tip).unwrap().is_empty());
     }
 
     #[test]
@@ -307,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    fn live_query_treats_a_missing_cursor_as_unavailable() {
+    fn query_with_a_missing_cursor_is_behind() {
         let dir = TempDir::new().unwrap();
         let db = ReferenceIndexDb::open(dir.path(), 2818, B256::ZERO).unwrap();
         let handle = handle_with_phase(db, 0, ReferenceIndexPhase::Live);
@@ -320,12 +329,12 @@ mod tests {
 
         assert!(matches!(
             handle.query_at(query, tip),
-            Err(ReferenceIndexError::IndexUnavailable)
+            Err(ReferenceIndexError::IndexBehind)
         ));
     }
 
     #[test]
-    fn live_query_treats_a_missing_cursor_hash_as_unavailable() {
+    fn query_with_a_missing_cursor_hash_is_behind() {
         let dir = TempDir::new().unwrap();
         let db = ReferenceIndexDb::open(dir.path(), 2818, B256::ZERO).unwrap();
         let tx = db.tx_mut().unwrap();
@@ -341,23 +350,16 @@ mod tests {
 
         assert!(matches!(
             handle.query_at(query, tip),
-            Err(ReferenceIndexError::IndexUnavailable)
+            Err(ReferenceIndexError::IndexBehind)
         ));
     }
 
     #[test]
-    fn pre_jade_query_is_complete_without_a_cursor() {
-        let dir = TempDir::new().unwrap();
-        let db = ReferenceIndexDb::open(dir.path(), 2818, B256::ZERO).unwrap();
-        let handle = handle_with_phase(db, 200, ReferenceIndexPhase::PreJade);
-        let query = ReferenceQuery::new(B256::with_last_byte(1), None, None).unwrap();
-        let tip = CanonicalTip {
-            number: 100,
-            hash: B256::repeat_byte(0xaa),
-            timestamp: 199,
-        };
-
-        assert!(handle.query_at(query, tip).unwrap().is_empty());
+    fn is_pre_jade_reflects_the_jade_timestamp() {
+        let handle = ReferenceIndexHandle::new(200);
+        assert!(handle.is_pre_jade(199));
+        assert!(!handle.is_pre_jade(200));
+        assert!(!handle.is_pre_jade(201));
     }
 
     #[test]

--- a/crates/reference-index/src/reader.rs
+++ b/crates/reference-index/src/reader.rs
@@ -138,6 +138,17 @@ impl ReferenceIndexHandle {
         &self.shared.metrics
     }
 
+    /// Record the outcome of a bounded server-side catch-up wait performed by
+    /// the RPC layer. `timed_out` is true when the wait budget elapsed and the
+    /// query still returned `IndexBehind`.
+    pub fn observe_rpc_wait(&self, waited: std::time::Duration, timed_out: bool) {
+        self.shared.metrics.rpc_waits_total.increment(1);
+        self.shared.metrics.rpc_wait_duration_seconds.record(waited);
+        if timed_out {
+            self.shared.metrics.rpc_wait_timeouts_total.increment(1);
+        }
+    }
+
     /// Execute a paginated query at an exact canonical chain snapshot.
     ///
     /// Cursor validation and result iteration share one MDBX read transaction,

--- a/crates/reference-index/src/runtime.rs
+++ b/crates/reference-index/src/runtime.rs
@@ -172,6 +172,7 @@ impl<C: CanonicalChain> ReferenceIndexRuntime<C> {
         &self,
         db: &ReferenceIndexDb,
         jade_first_block: u64,
+        finalized: Option<u64>,
         head: crate::CanonicalTip,
     ) -> Result<(), ReferenceIndexError> {
         let Some(cursor) = db.indexed_to()? else {
@@ -193,6 +194,13 @@ impl<C: CanonicalChain> ReferenceIndexRuntime<C> {
 
         self.handle.set_phase(ReferenceIndexPhase::Repairing);
         self.handle.metrics().reorgs_total.increment(1);
+        // A finalized block can never be reorged, so the rewind never needs to
+        // go below it — bounding the scan (and the retained `IndexedBlocks`
+        // breadcrumbs) instead of walking all the way back to the Jade start.
+        // Without finality yet, fall back to `jade_first_block`.
+        let rewind_floor = finalized
+            .map_or(jade_first_block, |finalized| finalized.max(jade_first_block))
+            .min(candidate);
         let mut ancestor = None;
         let mut number = candidate;
         loop {
@@ -205,7 +213,7 @@ impl<C: CanonicalChain> ReferenceIndexRuntime<C> {
                 ancestor = Some(number);
                 break;
             }
-            if number == jade_first_block {
+            if number == rewind_floor {
                 break;
             }
             number -= 1;
@@ -261,7 +269,8 @@ impl<C: CanonicalChain> ReferenceIndexRuntime<C> {
                     ))
                 })?,
         };
-        self.reconcile_cursor(&db, jade_first_block, head)?;
+        let finalized = self.chain.finalized_block_number()?;
+        self.reconcile_cursor(&db, jade_first_block, finalized, head)?;
         let start = db
             .indexed_to()?
             .map_or(jade_first_block, |cursor| cursor.saturating_add(1));
@@ -293,7 +302,7 @@ impl<C: CanonicalChain> ReferenceIndexRuntime<C> {
                 )));
             }
         }
-        commit_canonical_batch(&db, jade_first_block, start, &blocks)?;
+        commit_canonical_batch(&db, jade_first_block, start, &blocks, finalized)?;
         self.handle
             .metrics()
             .indexed_blocks_total
@@ -528,6 +537,7 @@ mod tests {
     #[derive(Clone, Debug)]
     struct TestChain {
         blocks: Arc<RwLock<Vec<CanonicalBlock>>>,
+        finalized: Arc<RwLock<Option<u64>>>,
     }
 
     impl TestChain {
@@ -542,6 +552,7 @@ mod tests {
                 .collect();
             Self {
                 blocks: Arc::new(RwLock::new(blocks)),
+                finalized: Arc::new(RwLock::new(None)),
             }
         }
 
@@ -553,6 +564,10 @@ mod tests {
 
         fn truncate(&self, len: u64) {
             self.blocks.write().truncate(len as usize);
+        }
+
+        fn set_finalized(&self, number: u64) {
+            *self.finalized.write() = Some(number);
         }
     }
 
@@ -581,6 +596,10 @@ mod tests {
                 .read()
                 .get(number as usize)
                 .map(|block| block.timestamp))
+        }
+
+        fn finalized_block_number(&self) -> Result<Option<u64>, crate::ReferenceIndexError> {
+            Ok(*self.finalized.read())
         }
 
         fn canonical_blocks(
@@ -683,6 +702,58 @@ mod tests {
     }
 
     #[test]
+    fn finalized_prunes_breadcrumbs_below_it_and_repairs_a_suffix_above_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let chain = TestChain::linear(10, 200);
+        let config = ReferenceIndexConfig::new(dir.path(), 2818, B256::ZERO, 200);
+        let (mut runtime, handle) = ReferenceIndexRuntime::new(config, chain.clone());
+        runtime.synchronize_once(false).unwrap();
+        assert_eq!(handle.phase(), ReferenceIndexPhase::Live);
+        // Without finality yet, every breadcrumb back to the Jade start is kept.
+        assert!(handle.db().unwrap().indexed_block_hash(0).unwrap().is_some());
+
+        // Finalize block 5, then reorg a suffix strictly above it.
+        chain.set_finalized(5);
+        chain.replace_suffix(7);
+        runtime.synchronize_once(false).unwrap();
+
+        assert_eq!(handle.phase(), ReferenceIndexPhase::Live);
+        let db = handle.db().unwrap();
+        // The suffix above finalized is repaired to the canonical hashes.
+        assert_eq!(
+            db.indexed_block_hash(7).unwrap(),
+            chain.canonical_hash(7).unwrap()
+        );
+        // Breadcrumbs below finalized are pruned; finalized and above survive.
+        assert!(db.indexed_block_hash(4).unwrap().is_none());
+        assert!(db.indexed_block_hash(5).unwrap().is_some());
+    }
+
+    #[test]
+    fn reorg_reaching_below_finalized_is_bounded_to_a_manual_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        let chain = TestChain::linear(10, 200);
+        let config = ReferenceIndexConfig::new(dir.path(), 2818, B256::ZERO, 200);
+        let (mut runtime, handle) = ReferenceIndexRuntime::new(config, chain.clone());
+        runtime.synchronize_once(false).unwrap();
+        assert_eq!(handle.phase(), ReferenceIndexPhase::Live);
+
+        // Finalize block 5, then diverge a range that reaches below it. A
+        // finalized block cannot legitimately reorg, so rather than scanning all
+        // the way back to the Jade start the rewind stops at finalized and
+        // surfaces a manual rebuild instead of silently repairing corruption.
+        chain.set_finalized(5);
+        chain.replace_suffix(3);
+        let error = runtime.synchronize_once(false).unwrap_err();
+
+        assert!(matches!(
+            error,
+            ReferenceIndexError::ManualRebuildRequired { .. }
+        ));
+        assert_eq!(handle.phase(), ReferenceIndexPhase::Unavailable);
+    }
+
+    #[test]
     fn pure_revert_rolls_the_cursor_back_to_the_new_head() {
         let dir = tempfile::tempdir().unwrap();
         let chain = TestChain::linear(10, 200);
@@ -740,6 +811,10 @@ mod tests {
 
         fn block_timestamp(&self, number: u64) -> Result<Option<u64>, ReferenceIndexError> {
             self.0.block_timestamp(number)
+        }
+
+        fn finalized_block_number(&self) -> Result<Option<u64>, ReferenceIndexError> {
+            self.0.finalized_block_number()
         }
 
         fn canonical_blocks(

--- a/crates/reference-index/src/runtime.rs
+++ b/crates/reference-index/src/runtime.rs
@@ -199,7 +199,9 @@ impl<C: CanonicalChain> ReferenceIndexRuntime<C> {
         // breadcrumbs) instead of walking all the way back to the Jade start.
         // Without finality yet, fall back to `jade_first_block`.
         let rewind_floor = finalized
-            .map_or(jade_first_block, |finalized| finalized.max(jade_first_block))
+            .map_or(jade_first_block, |finalized| {
+                finalized.max(jade_first_block)
+            })
             .min(candidate);
         let mut ancestor = None;
         let mut number = candidate;
@@ -710,7 +712,14 @@ mod tests {
         runtime.synchronize_once(false).unwrap();
         assert_eq!(handle.phase(), ReferenceIndexPhase::Live);
         // Without finality yet, every breadcrumb back to the Jade start is kept.
-        assert!(handle.db().unwrap().indexed_block_hash(0).unwrap().is_some());
+        assert!(
+            handle
+                .db()
+                .unwrap()
+                .indexed_block_hash(0)
+                .unwrap()
+                .is_some()
+        );
 
         // Finalize block 5, then reorg a suffix strictly above it.
         chain.set_finalized(5);

--- a/crates/reference-index/src/runtime.rs
+++ b/crates/reference-index/src/runtime.rs
@@ -604,13 +604,9 @@ mod tests {
         runtime.synchronize_once(false).unwrap();
 
         assert_eq!(handle.phase(), crate::ReferenceIndexPhase::PreJade);
-        let query = ReferenceQuery::new(B256::with_last_byte(0xaa), None, None).unwrap();
-        assert!(
-            handle
-                .query_at(query, chain.head().unwrap())
-                .unwrap()
-                .is_empty()
-        );
+        // Pre-Jade is answered as a complete empty result at the RPC layer via
+        // `is_pre_jade`; the reader never sees the query and no cursor is written.
+        assert!(handle.is_pre_jade(chain.head().unwrap().timestamp));
         assert_eq!(handle.db().unwrap().indexed_to().unwrap(), None);
     }
 
@@ -643,14 +639,21 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let chain = TestChain::linear(10, 200);
         let config = ReferenceIndexConfig::new(dir.path(), 2818, B256::ZERO, 200);
-        let (mut runtime, handle) = ReferenceIndexRuntime::new(config, chain);
+        let (mut runtime, handle) = ReferenceIndexRuntime::new(config, chain.clone());
         runtime.synchronize_once(false).unwrap();
-        let generation = handle.generation();
+        assert_eq!(handle.phase(), ReferenceIndexPhase::Live);
 
         runtime.synchronize_once(false).unwrap();
 
         assert_eq!(handle.phase(), ReferenceIndexPhase::Live);
-        assert_eq!(handle.generation(), generation);
+        // A no-op reconciliation still serves reads at the unchanged tip.
+        let query = ReferenceQuery::new(B256::with_last_byte(0xaa), None, None).unwrap();
+        assert!(
+            handle
+                .query_at(query, chain.head().unwrap())
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/reference-index/src/source.rs
+++ b/crates/reference-index/src/source.rs
@@ -4,7 +4,9 @@ use crate::{CanonicalTip, ReferenceIndexError};
 use alloy_consensus::{BlockHeader, Sealable};
 use alloy_primitives::B256;
 use morph_primitives::MorphTxEnvelope;
-use reth_provider::{BlockHashReader, BlockReader, BlockReaderIdExt, HeaderProvider};
+use reth_provider::{
+    BlockHashReader, BlockIdReader, BlockReader, BlockReaderIdExt, HeaderProvider,
+};
 use std::ops::RangeInclusive;
 
 /// Canonical block fields required to build the reference index.
@@ -30,6 +32,13 @@ pub trait CanonicalChain: Clone + Send + Sync + 'static {
 
     /// Return the canonical timestamp at `number`, if the header is retained.
     fn block_timestamp(&self, number: u64) -> Result<Option<u64>, ReferenceIndexError>;
+
+    /// Return the L1 finalized canonical block number, if finality is known.
+    ///
+    /// A finalized block can never be reorged, so this is the true lower bound
+    /// for reorg rewind and the pruning floor for reorg breadcrumbs. `None`
+    /// means finality is not yet established (fall back to the Jade start).
+    fn finalized_block_number(&self) -> Result<Option<u64>, ReferenceIndexError>;
 
     /// Load an inclusive range of canonical blocks with their transaction bodies.
     fn canonical_blocks(
@@ -62,6 +71,10 @@ where
 
     fn block_timestamp(&self, number: u64) -> Result<Option<u64>, ReferenceIndexError> {
         Ok(HeaderProvider::header_by_number(self, number)?.map(|header| header.timestamp()))
+    }
+
+    fn finalized_block_number(&self) -> Result<Option<u64>, ReferenceIndexError> {
+        Ok(BlockIdReader::finalized_block_number(self)?)
     }
 
     fn canonical_blocks(

--- a/crates/reference-index/src/writer.rs
+++ b/crates/reference-index/src/writer.rs
@@ -136,6 +136,39 @@ pub(crate) fn set_jade_first_block_number<Tx: DbTxMut>(
     Ok(())
 }
 
+/// Prune `IndexedBlocks` breadcrumbs strictly below `floor`.
+///
+/// Only the `block_number -> block_hash` breadcrumbs consumed by reorg rewind
+/// are removed; the `ReferenceIndex` / `BlockReferenceIndex` query data is never
+/// touched, so pruned history stays fully queryable. Callers pass a floor at or
+/// below both the durable cursor tip and the reorg rewind lower bound, so reads
+/// and reconciliation are unaffected.
+pub(crate) fn prune_indexed_blocks_before<Tx: DbTxMut>(
+    tx: &Tx,
+    floor: u64,
+) -> Result<(), ReferenceIndexError> {
+    if floor == 0 {
+        return Ok(());
+    }
+
+    let mut stale = Vec::new();
+    {
+        let mut cursor = tx.cursor_write::<IndexedBlocks>()?;
+        let mut next = cursor.first()?;
+        while let Some((key, _)) = next {
+            if key.block_number >= floor {
+                break;
+            }
+            stale.push(key);
+            next = cursor.next()?;
+        }
+    }
+    for key in stale {
+        tx.delete::<IndexedBlocks>(key, None)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/reference-index/src/writer.rs
+++ b/crates/reference-index/src/writer.rs
@@ -5,6 +5,7 @@
 //! single atomic commit.
 
 use crate::{
+    DEFAULT_BACKFILL_BATCH_BLOCKS,
     db::{IndexMetaKey, encode_u64},
     tables::{
         BlockHashValue, BlockReferenceIndex, BlockReferenceKey, BlockTimestampValue, IndexMeta,
@@ -142,7 +143,9 @@ pub(crate) fn set_jade_first_block_number<Tx: DbTxMut>(
 /// are removed; the `ReferenceIndex` / `BlockReferenceIndex` query data is never
 /// touched, so pruned history stays fully queryable. Callers pass a floor at or
 /// below both the durable cursor tip and the reorg rewind lower bound, so reads
-/// and reconciliation are unaffected.
+/// and reconciliation are unaffected. Each call deletes at most
+/// [`DEFAULT_BACKFILL_BATCH_BLOCKS`] rows; the first remaining key acts as the
+/// durable progress cursor for the next canonical commit.
 pub(crate) fn prune_indexed_blocks_before<Tx: DbTxMut>(
     tx: &Tx,
     floor: u64,
@@ -155,7 +158,10 @@ pub(crate) fn prune_indexed_blocks_before<Tx: DbTxMut>(
     {
         let mut cursor = tx.cursor_write::<IndexedBlocks>()?;
         let mut next = cursor.first()?;
-        while let Some((key, _)) = next {
+        while stale.len() < DEFAULT_BACKFILL_BATCH_BLOCKS as usize {
+            let Some((key, _)) = next else {
+                break;
+            };
             if key.block_number >= floor {
                 break;
             }

--- a/crates/rpc/src/morph/handler.rs
+++ b/crates/rpc/src/morph/handler.rs
@@ -260,6 +260,10 @@ mod tests {
             Ok((number == self.block.number).then_some(self.block.timestamp))
         }
 
+        fn finalized_block_number(&self) -> Result<Option<u64>, ReferenceIndexError> {
+            Ok(None)
+        }
+
         fn canonical_blocks(
             &self,
             range: RangeInclusive<u64>,

--- a/crates/rpc/src/morph/handler.rs
+++ b/crates/rpc/src/morph/handler.rs
@@ -84,6 +84,14 @@ where
             timestamp: header.timestamp(),
         };
 
+        // Pre-Jade is a complete, terminal empty answer: no reference-carrying
+        // transaction can exist before Jade, so return `[]` without touching the
+        // index. This must not be `IndexBehind` (which instructs clients to
+        // retry) — before Jade there is nothing to wait for.
+        if self.ctx.reference_index.is_pre_jade(canonical_tip.timestamp) {
+            return Ok(Vec::new());
+        }
+
         let result = self
             .ctx
             .reference_index

--- a/crates/rpc/src/morph/handler.rs
+++ b/crates/rpc/src/morph/handler.rs
@@ -7,13 +7,23 @@ use jsonrpsee::{
     types::{ErrorCode, ErrorObjectOwned},
 };
 use morph_reference_index::{
-    CanonicalTip, ReferenceIndexError, ReferenceIndexHandle, ReferenceQuery,
+    CanonicalTip, ReferenceIndexError, ReferenceIndexHandle, ReferenceIndexPhase, ReferenceQuery,
     ReferenceTransactionResult,
 };
 use reth_storage_api::{BlockNumReader, HeaderProvider};
+use std::time::{Duration, Instant};
 use tracing;
 
 const TARGET: &str = "morph::reference_index_rpc";
+
+/// Upper bound on how long a query waits for the asynchronous index runtime to
+/// catch up to the canonical tip before returning `IndexBehind`. The steady-state
+/// lag is a few milliseconds, so the vast majority of waits resolve well within
+/// this budget and return real data instead of forcing the client to retry.
+const INDEX_WAIT_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Poll cadence while waiting for the index cursor to reach the canonical tip.
+const INDEX_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 // ── Context ──────────────────────────────────────────────────────────────────
 
@@ -61,54 +71,114 @@ where
         let query =
             ReferenceQuery::new(args.reference, args.offset, args.limit).map_err(to_rpc_error)?;
 
-        let before = self
-            .ctx
-            .provider
-            .chain_info()
-            .map_err(ReferenceIndexError::from)
-            .map_err(to_rpc_error)?;
-        let header = self
-            .ctx
-            .provider
-            .header(before.best_hash)
-            .map_err(ReferenceIndexError::from)
-            .map_err(to_rpc_error)?
-            .ok_or(ReferenceIndexError::IndexBehind)
-            .map_err(to_rpc_error)?;
-        if header.number() != before.best_number {
-            return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
+        // The index runtime is asynchronous (PR #141 decoupled it from block
+        // execution), so for a few milliseconds after a new block becomes the
+        // canonical tip the durable cursor still lags it. Rather than returning
+        // `IndexBehind` immediately — forcing the client into a retry loop —
+        // wait a bounded amount for the runtime to catch up. This is a
+        // `blocking` RPC handler, so the sleep only occupies a blocking-pool
+        // thread (never the async reactor) and is strictly bounded by
+        // `INDEX_WAIT_TIMEOUT`.
+        let deadline = Instant::now() + INDEX_WAIT_TIMEOUT;
+        let wait_started = Instant::now();
+        let mut waited = false;
+
+        loop {
+            let before = self
+                .ctx
+                .provider
+                .chain_info()
+                .map_err(ReferenceIndexError::from)
+                .map_err(to_rpc_error)?;
+            let header = self
+                .ctx
+                .provider
+                .header(before.best_hash)
+                .map_err(ReferenceIndexError::from)
+                .map_err(to_rpc_error)?
+                .ok_or(ReferenceIndexError::IndexBehind)
+                .map_err(to_rpc_error)?;
+            if header.number() != before.best_number {
+                return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
+            }
+            let canonical_tip = CanonicalTip {
+                number: before.best_number,
+                hash: before.best_hash,
+                timestamp: header.timestamp(),
+            };
+
+            // Pre-Jade is a complete, terminal empty answer: no reference-carrying
+            // transaction can exist before Jade, so return `[]` without touching
+            // the index. This must not be `IndexBehind` (which instructs clients
+            // to retry) — before Jade there is nothing to wait for.
+            if self.ctx.reference_index.is_pre_jade(canonical_tip.timestamp) {
+                if waited {
+                    self.ctx
+                        .reference_index
+                        .observe_rpc_wait(wait_started.elapsed(), false);
+                }
+                return Ok(Vec::new());
+            }
+
+            match self.ctx.reference_index.query_at(query, canonical_tip) {
+                Ok(result) => {
+                    let after = self
+                        .ctx
+                        .provider
+                        .chain_info()
+                        .map_err(ReferenceIndexError::from)
+                        .map_err(to_rpc_error)?;
+                    if after == before {
+                        if waited {
+                            self.ctx
+                                .reference_index
+                                .observe_rpc_wait(wait_started.elapsed(), false);
+                        }
+                        return Ok(result);
+                    }
+                    // The tip advanced while we read; this snapshot no longer
+                    // matches a stable head. Retry against the new tip while the
+                    // wait budget allows, otherwise report behind.
+                    if Instant::now() >= deadline {
+                        if waited {
+                            self.ctx
+                                .reference_index
+                                .observe_rpc_wait(wait_started.elapsed(), true);
+                        }
+                        return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
+                    }
+                }
+                Err(ReferenceIndexError::IndexBehind) => {
+                    // Waiting only pays off for the steady-state per-block lag
+                    // (phase oscillates Live<->Backfill for the newest block and
+                    // catches up in a few ms). Rapid-sync `Deferred` (indexing
+                    // intentionally paused) and the one-time `PreJade` activation
+                    // boundary catch up on a much coarser timescale, so fail fast
+                    // instead of burning the whole budget.
+                    if matches!(
+                        self.ctx.reference_index.phase(),
+                        ReferenceIndexPhase::Deferred | ReferenceIndexPhase::PreJade
+                    ) {
+                        if waited {
+                            self.ctx
+                                .reference_index
+                                .observe_rpc_wait(wait_started.elapsed(), true);
+                        }
+                        return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
+                    }
+                    if Instant::now() >= deadline {
+                        self.ctx
+                            .reference_index
+                            .observe_rpc_wait(wait_started.elapsed(), true);
+                        return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
+                    }
+                }
+                Err(other) => return Err(to_rpc_error(other)),
+            }
+
+            waited = true;
+            std::thread::sleep(INDEX_WAIT_POLL_INTERVAL);
         }
-        let canonical_tip = CanonicalTip {
-            number: before.best_number,
-            hash: before.best_hash,
-            timestamp: header.timestamp(),
-        };
-
-        // Pre-Jade is a complete, terminal empty answer: no reference-carrying
-        // transaction can exist before Jade, so return `[]` without touching the
-        // index. This must not be `IndexBehind` (which instructs clients to
-        // retry) — before Jade there is nothing to wait for.
-        if self.ctx.reference_index.is_pre_jade(canonical_tip.timestamp) {
-            return Ok(Vec::new());
-        }
-
-        let result = self
-            .ctx
-            .reference_index
-            .query_at(query, canonical_tip)
-            .map_err(to_rpc_error)?;
-
-        let after = self
-            .ctx
-            .provider
-            .chain_info()
-            .map_err(ReferenceIndexError::from)
-            .map_err(to_rpc_error)?;
-        if after != before {
-            return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
-        }
-
-        Ok(result)
     }
 }
 
@@ -390,6 +460,48 @@ mod tests {
 
         assert_eq!(error.code(), -32000);
         assert_eq!(error.message(), "reference index is behind");
+    }
+
+    #[test]
+    fn rapid_sync_deferred_fails_fast_without_burning_the_wait_budget() {
+        // Rapid-sync `Deferred`: a post-Jade query must return `IndexBehind`
+        // promptly rather than sleeping out the full `INDEX_WAIT_TIMEOUT`, since
+        // the runtime will not catch up while indexing is intentionally paused.
+        let dir = tempfile::tempdir().unwrap();
+        let hash = B256::repeat_byte(0x11);
+        let chain = TestChain {
+            block: CanonicalBlock {
+                number: 0,
+                hash,
+                timestamp: 100,
+                transactions: Vec::new(),
+            },
+        };
+        let config = ReferenceIndexConfig::new(dir.path(), 2818, B256::ZERO, 0);
+        let (mut runtime, handle) = ReferenceIndexRuntime::new(config, chain);
+        runtime.synchronize_once(true).unwrap();
+        assert_eq!(handle.phase(), ReferenceIndexPhase::Deferred);
+
+        let provider = TestProvider::new(
+            [ChainInfo {
+                best_hash: hash,
+                best_number: 0,
+            }],
+            BTreeMap::from([(hash, header(0, 100))]),
+        );
+        let handler = MorphRpcHandler::new(MorphRpc::new(handle, provider));
+
+        let started = Instant::now();
+        let error = handler
+            .get_transaction_hashes_by_reference(args())
+            .unwrap_err();
+        let elapsed = started.elapsed();
+
+        assert_eq!(error.message(), "reference index is behind");
+        assert!(
+            elapsed < INDEX_WAIT_TIMEOUT,
+            "deferred query should fail fast, took {elapsed:?}"
+        );
     }
 
     #[test]

--- a/crates/rpc/src/morph/handler.rs
+++ b/crates/rpc/src/morph/handler.rs
@@ -25,6 +25,11 @@ const INDEX_WAIT_TIMEOUT: Duration = Duration::from_millis(100);
 /// Poll cadence while waiting for the index cursor to reach the canonical tip.
 const INDEX_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
+fn next_poll_delay(now: Instant, deadline: Instant) -> Option<Duration> {
+    let remaining = deadline.saturating_duration_since(now);
+    (!remaining.is_zero()).then(|| INDEX_WAIT_POLL_INTERVAL.min(remaining))
+}
+
 // ── Context ──────────────────────────────────────────────────────────────────
 
 /// `morph_` namespace context.  All dependencies are required; no `Option<>`.
@@ -49,14 +54,84 @@ impl<Provider> MorphRpc<Provider> {
 // ── Handler ───────────────────────────────────────────────────────────────────
 
 /// Handler that wraps [`MorphRpc`] and implements the jsonrpsee server trait.
+#[cfg(test)]
+#[derive(Clone)]
+struct WaitObserver(std::sync::Arc<dyn Fn(bool) + Send + Sync>);
+
+#[cfg(test)]
+impl std::fmt::Debug for WaitObserver {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("WaitObserver")
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MorphRpcHandler<Provider> {
     ctx: MorphRpc<Provider>,
+    #[cfg(test)]
+    wait_observer: Option<WaitObserver>,
 }
 
 impl<Provider> MorphRpcHandler<Provider> {
     pub const fn new(ctx: MorphRpc<Provider>) -> Self {
-        Self { ctx }
+        Self {
+            ctx,
+            #[cfg(test)]
+            wait_observer: None,
+        }
+    }
+
+    fn observe_rpc_wait(&self, waited: Duration, timed_out: bool) {
+        self.ctx.reference_index.observe_rpc_wait(waited, timed_out);
+        #[cfg(test)]
+        if let Some(observer) = &self.wait_observer {
+            (observer.0)(timed_out);
+        }
+    }
+
+    #[cfg(test)]
+    fn with_wait_observer(mut self, observer: impl Fn(bool) + Send + Sync + 'static) -> Self {
+        self.wait_observer = Some(WaitObserver(std::sync::Arc::new(observer)));
+        self
+    }
+}
+
+struct RpcWaitGuard<'a, Provider> {
+    handler: &'a MorphRpcHandler<Provider>,
+    started: Instant,
+    waited: bool,
+    timed_out: bool,
+}
+
+impl<'a, Provider> RpcWaitGuard<'a, Provider> {
+    fn new(handler: &'a MorphRpcHandler<Provider>) -> Self {
+        Self {
+            handler,
+            started: Instant::now(),
+            waited: false,
+            timed_out: false,
+        }
+    }
+
+    const fn has_waited(&self) -> bool {
+        self.waited
+    }
+
+    const fn begin_wait(&mut self) {
+        self.waited = true;
+    }
+
+    const fn mark_timed_out(&mut self) {
+        self.timed_out = true;
+    }
+}
+
+impl<Provider> Drop for RpcWaitGuard<'_, Provider> {
+    fn drop(&mut self) {
+        if self.waited {
+            self.handler
+                .observe_rpc_wait(self.started.elapsed(), self.timed_out);
+        }
     }
 }
 
@@ -80,10 +155,14 @@ where
         // thread (never the async reactor) and is strictly bounded by
         // `INDEX_WAIT_TIMEOUT`.
         let deadline = Instant::now() + INDEX_WAIT_TIMEOUT;
-        let wait_started = Instant::now();
-        let mut waited = false;
+        let mut wait = RpcWaitGuard::new(self);
 
         loop {
+            if wait.has_waited() && Instant::now() >= deadline {
+                wait.mark_timed_out();
+                return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
+            }
+
             let before = self
                 .ctx
                 .provider
@@ -111,73 +190,63 @@ where
             // transaction can exist before Jade, so return `[]` without touching
             // the index. This must not be `IndexBehind` (which instructs clients
             // to retry) — before Jade there is nothing to wait for.
-            if self.ctx.reference_index.is_pre_jade(canonical_tip.timestamp) {
-                if waited {
-                    self.ctx
-                        .reference_index
-                        .observe_rpc_wait(wait_started.elapsed(), false);
+            if self
+                .ctx
+                .reference_index
+                .is_pre_jade(canonical_tip.timestamp)
+            {
+                let after = self
+                    .ctx
+                    .provider
+                    .chain_info()
+                    .map_err(ReferenceIndexError::from)
+                    .map_err(to_rpc_error)?;
+                if after == before {
+                    return Ok(Vec::new());
                 }
-                return Ok(Vec::new());
+                // The pre-Jade snapshot changed while it was bracketed. Do not
+                // query the index with the stale tip: wait once, then rebuild a
+                // fresh canonical snapshot on the next iteration.
+            } else {
+                match self.ctx.reference_index.query_at(query, canonical_tip) {
+                    Ok(result) => {
+                        let after = self
+                            .ctx
+                            .provider
+                            .chain_info()
+                            .map_err(ReferenceIndexError::from)
+                            .map_err(to_rpc_error)?;
+                        if after == before {
+                            return Ok(result);
+                        }
+                        // The tip advanced while we read; this snapshot no longer
+                        // matches a stable head. Retry against the new tip while the
+                        // wait budget allows, otherwise report behind.
+                    }
+                    Err(ReferenceIndexError::IndexBehind) => {
+                        // Waiting only pays off for the steady-state per-block lag
+                        // (phase oscillates Live<->Backfill for the newest block and
+                        // catches up in a few ms). Rapid-sync `Deferred` (indexing
+                        // intentionally paused) and the one-time `PreJade` activation
+                        // boundary catch up on a much coarser timescale, so fail fast
+                        // instead of burning the whole budget.
+                        if matches!(
+                            self.ctx.reference_index.phase(),
+                            ReferenceIndexPhase::Deferred | ReferenceIndexPhase::PreJade
+                        ) {
+                            return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
+                        }
+                    }
+                    Err(other) => return Err(to_rpc_error(other)),
+                }
             }
 
-            match self.ctx.reference_index.query_at(query, canonical_tip) {
-                Ok(result) => {
-                    let after = self
-                        .ctx
-                        .provider
-                        .chain_info()
-                        .map_err(ReferenceIndexError::from)
-                        .map_err(to_rpc_error)?;
-                    if after == before {
-                        if waited {
-                            self.ctx
-                                .reference_index
-                                .observe_rpc_wait(wait_started.elapsed(), false);
-                        }
-                        return Ok(result);
-                    }
-                    // The tip advanced while we read; this snapshot no longer
-                    // matches a stable head. Retry against the new tip while the
-                    // wait budget allows, otherwise report behind.
-                    if Instant::now() >= deadline {
-                        if waited {
-                            self.ctx
-                                .reference_index
-                                .observe_rpc_wait(wait_started.elapsed(), true);
-                        }
-                        return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
-                    }
-                }
-                Err(ReferenceIndexError::IndexBehind) => {
-                    // Waiting only pays off for the steady-state per-block lag
-                    // (phase oscillates Live<->Backfill for the newest block and
-                    // catches up in a few ms). Rapid-sync `Deferred` (indexing
-                    // intentionally paused) and the one-time `PreJade` activation
-                    // boundary catch up on a much coarser timescale, so fail fast
-                    // instead of burning the whole budget.
-                    if matches!(
-                        self.ctx.reference_index.phase(),
-                        ReferenceIndexPhase::Deferred | ReferenceIndexPhase::PreJade
-                    ) {
-                        if waited {
-                            self.ctx
-                                .reference_index
-                                .observe_rpc_wait(wait_started.elapsed(), true);
-                        }
-                        return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
-                    }
-                    if Instant::now() >= deadline {
-                        self.ctx
-                            .reference_index
-                            .observe_rpc_wait(wait_started.elapsed(), true);
-                        return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
-                    }
-                }
-                Err(other) => return Err(to_rpc_error(other)),
-            }
-
-            waited = true;
-            std::thread::sleep(INDEX_WAIT_POLL_INTERVAL);
+            wait.begin_wait();
+            let Some(delay) = next_poll_delay(Instant::now(), deadline) else {
+                wait.mark_timed_out();
+                return Err(to_rpc_error(ReferenceIndexError::IndexBehind));
+            };
+            std::thread::sleep(delay);
         }
     }
 }
@@ -235,7 +304,10 @@ mod tests {
     use std::{
         collections::{BTreeMap, VecDeque},
         ops::{RangeBounds, RangeInclusive},
-        sync::{Arc, Mutex},
+        sync::{
+            Arc, Barrier, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
     };
 
     #[derive(Clone, Debug)]
@@ -277,9 +349,83 @@ mod tests {
     }
 
     #[derive(Clone, Debug)]
+    struct GrowingTestChain {
+        blocks: Arc<Mutex<Vec<CanonicalBlock>>>,
+    }
+
+    impl GrowingTestChain {
+        fn new(block: CanonicalBlock) -> Self {
+            Self {
+                blocks: Arc::new(Mutex::new(vec![block])),
+            }
+        }
+
+        fn push(&self, block: CanonicalBlock) {
+            self.blocks.lock().unwrap().push(block);
+        }
+    }
+
+    impl CanonicalChain for GrowingTestChain {
+        fn head(&self) -> Result<CanonicalTip, ReferenceIndexError> {
+            let blocks = self.blocks.lock().unwrap();
+            let block = blocks.last().unwrap();
+            Ok(CanonicalTip {
+                number: block.number,
+                hash: block.hash,
+                timestamp: block.timestamp,
+            })
+        }
+
+        fn canonical_hash(&self, number: u64) -> Result<Option<B256>, ReferenceIndexError> {
+            Ok(self
+                .blocks
+                .lock()
+                .unwrap()
+                .iter()
+                .find_map(|block| (block.number == number).then_some(block.hash)))
+        }
+
+        fn block_timestamp(&self, number: u64) -> Result<Option<u64>, ReferenceIndexError> {
+            Ok(self
+                .blocks
+                .lock()
+                .unwrap()
+                .iter()
+                .find_map(|block| (block.number == number).then_some(block.timestamp)))
+        }
+
+        fn finalized_block_number(&self) -> Result<Option<u64>, ReferenceIndexError> {
+            Ok(None)
+        }
+
+        fn canonical_blocks(
+            &self,
+            range: RangeInclusive<u64>,
+        ) -> Result<Vec<CanonicalBlock>, ReferenceIndexError> {
+            Ok(self
+                .blocks
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|block| range.contains(&block.number))
+                .cloned()
+                .collect())
+        }
+    }
+
+    #[derive(Debug)]
+    struct ChainInfoGate {
+        call: usize,
+        calls: AtomicUsize,
+        reached: Arc<Barrier>,
+        released: Arc<Barrier>,
+    }
+
+    #[derive(Clone, Debug)]
     struct TestProvider {
         chain_info: Arc<Mutex<VecDeque<ChainInfo>>>,
         headers: Arc<BTreeMap<B256, MorphHeader>>,
+        gate: Option<Arc<ChainInfoGate>>,
     }
 
     impl TestProvider {
@@ -290,10 +436,30 @@ mod tests {
             Self {
                 chain_info: Arc::new(Mutex::new(chain_info.into_iter().collect())),
                 headers: Arc::new(headers),
+                gate: None,
             }
         }
 
+        fn gate_chain_info_call(mut self, call: usize) -> (Self, Arc<Barrier>, Arc<Barrier>) {
+            let reached = Arc::new(Barrier::new(2));
+            let released = Arc::new(Barrier::new(2));
+            self.gate = Some(Arc::new(ChainInfoGate {
+                call,
+                calls: AtomicUsize::new(0),
+                reached: reached.clone(),
+                released: released.clone(),
+            }));
+            (self, reached, released)
+        }
+
         fn info(&self) -> ChainInfo {
+            if let Some(gate) = &self.gate {
+                let call = gate.calls.fetch_add(1, Ordering::Relaxed) + 1;
+                if call == gate.call {
+                    gate.reached.wait();
+                    gate.released.wait();
+                }
+            }
             let mut infos = self.chain_info.lock().unwrap();
             if infos.len() > 1 {
                 infos.pop_front().unwrap()
@@ -467,6 +633,63 @@ mod tests {
     }
 
     #[test]
+    fn pre_jade_empty_result_is_rejected_if_head_crosses_jade() {
+        let pre_jade_hash = B256::repeat_byte(0x11);
+        let jade_hash = B256::repeat_byte(0x22);
+        let (_dir, handle) = synced_handle(200, 199, pre_jade_hash);
+        let provider = TestProvider::new(
+            [
+                ChainInfo {
+                    best_hash: pre_jade_hash,
+                    best_number: 0,
+                },
+                ChainInfo {
+                    best_hash: jade_hash,
+                    best_number: 1,
+                },
+            ],
+            BTreeMap::from([(pre_jade_hash, header(0, 199)), (jade_hash, header(1, 200))]),
+        );
+        let handler = MorphRpcHandler::new(MorphRpc::new(handle, provider));
+
+        let error = handler
+            .get_transaction_hashes_by_reference(args())
+            .expect_err("a head change across Jade must invalidate the empty snapshot");
+
+        assert_eq!(error.code(), -32000);
+        assert_eq!(error.message(), "reference index is behind");
+    }
+
+    #[test]
+    fn changed_pre_jade_snapshot_retries_without_querying_the_opening_index() {
+        let first_hash = B256::repeat_byte(0x11);
+        let second_hash = B256::repeat_byte(0x22);
+        let handle = ReferenceIndexHandle::new(200);
+        let provider = TestProvider::new(
+            [
+                ChainInfo {
+                    best_hash: first_hash,
+                    best_number: 0,
+                },
+                ChainInfo {
+                    best_hash: second_hash,
+                    best_number: 1,
+                },
+                ChainInfo {
+                    best_hash: second_hash,
+                    best_number: 1,
+                },
+            ],
+            BTreeMap::from([(first_hash, header(0, 100)), (second_hash, header(1, 101))]),
+        );
+        let handler = MorphRpcHandler::new(MorphRpc::new(handle, provider));
+
+        let results = handler.get_transaction_hashes_by_reference(args()).unwrap();
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
     fn rapid_sync_deferred_fails_fast_without_burning_the_wait_budget() {
         // Rapid-sync `Deferred`: a post-Jade query must return `IndexBehind`
         // promptly rather than sleeping out the full `INDEX_WAIT_TIMEOUT`, since
@@ -495,17 +718,177 @@ mod tests {
         );
         let handler = MorphRpcHandler::new(MorphRpc::new(handle, provider));
 
-        let started = Instant::now();
         let error = handler
             .get_transaction_hashes_by_reference(args())
             .unwrap_err();
-        let elapsed = started.elapsed();
 
         assert_eq!(error.message(), "reference index is behind");
-        assert!(
-            elapsed < INDEX_WAIT_TIMEOUT,
-            "deferred query should fail fast, took {elapsed:?}"
+    }
+
+    #[test]
+    fn poll_delay_never_exceeds_the_remaining_budget() {
+        let now = Instant::now();
+
+        assert_eq!(next_poll_delay(now, now), None);
+        assert_eq!(
+            next_poll_delay(now, now + Duration::from_millis(2)),
+            Some(Duration::from_millis(2))
         );
+        assert_eq!(
+            next_poll_delay(now, now + Duration::from_millis(10)),
+            Some(INDEX_WAIT_POLL_INTERVAL)
+        );
+    }
+
+    #[test]
+    fn live_lag_wait_eventually_returns_behind() {
+        let indexed_hash = B256::repeat_byte(0x11);
+        let head_hash = B256::repeat_byte(0x22);
+        let (_dir, handle) = synced_handle(0, 100, indexed_hash);
+        let provider = TestProvider::new(
+            [ChainInfo {
+                best_hash: head_hash,
+                best_number: 1,
+            }],
+            BTreeMap::from([(head_hash, header(1, 101))]),
+        );
+        let handler = MorphRpcHandler::new(MorphRpc::new(handle, provider));
+
+        let error = handler
+            .get_transaction_hashes_by_reference(args())
+            .unwrap_err();
+
+        assert_eq!(error.message(), "reference index is behind");
+    }
+
+    #[test]
+    fn live_lag_wait_returns_from_the_same_request_after_runtime_catches_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let indexed_hash = B256::repeat_byte(0x11);
+        let head_hash = B256::repeat_byte(0x22);
+        let chain = GrowingTestChain::new(CanonicalBlock {
+            number: 0,
+            hash: indexed_hash,
+            timestamp: 100,
+            transactions: Vec::new(),
+        });
+        let config = ReferenceIndexConfig::new(dir.path(), 2818, B256::ZERO, 0);
+        let (mut runtime, handle) = ReferenceIndexRuntime::new(config, chain.clone());
+        runtime.synchronize_once(false).unwrap();
+        chain.push(CanonicalBlock {
+            number: 1,
+            hash: head_hash,
+            timestamp: 101,
+            transactions: Vec::new(),
+        });
+
+        let provider = TestProvider::new(
+            [ChainInfo {
+                best_hash: head_hash,
+                best_number: 1,
+            }],
+            BTreeMap::from([(head_hash, header(1, 101))]),
+        );
+        let (provider, second_attempt, catch_up_complete) = provider.gate_chain_info_call(2);
+        let catch_up = std::thread::spawn(move || {
+            second_attempt.wait();
+            runtime.synchronize_once(false).unwrap();
+            catch_up_complete.wait();
+        });
+        let handler = MorphRpcHandler::new(MorphRpc::new(handle, provider));
+
+        let results = handler.get_transaction_hashes_by_reference(args()).unwrap();
+        catch_up.join().unwrap();
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn deferred_transition_after_wait_is_not_counted_as_a_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let indexed_hash = B256::repeat_byte(0x11);
+        let head_hash = B256::repeat_byte(0x22);
+        let chain = GrowingTestChain::new(CanonicalBlock {
+            number: 0,
+            hash: indexed_hash,
+            timestamp: 100,
+            transactions: Vec::new(),
+        });
+        let config = ReferenceIndexConfig::new(dir.path(), 2818, B256::ZERO, 0);
+        let (mut runtime, handle) = ReferenceIndexRuntime::new(config, chain.clone());
+        runtime.synchronize_once(false).unwrap();
+        chain.push(CanonicalBlock {
+            number: 1,
+            hash: head_hash,
+            timestamp: 101,
+            transactions: Vec::new(),
+        });
+
+        let provider = TestProvider::new(
+            [ChainInfo {
+                best_hash: head_hash,
+                best_number: 1,
+            }],
+            BTreeMap::from([(head_hash, header(1, 101))]),
+        );
+        let (provider, second_attempt, transition_complete) = provider.gate_chain_info_call(2);
+        let transition = std::thread::spawn(move || {
+            second_attempt.wait();
+            runtime.synchronize_once(true).unwrap();
+            transition_complete.wait();
+        });
+        let phase = handle.clone();
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let observed_outcomes = outcomes.clone();
+        let handler = MorphRpcHandler::new(MorphRpc::new(handle, provider)).with_wait_observer(
+            move |timed_out| {
+                observed_outcomes.lock().unwrap().push(timed_out);
+            },
+        );
+
+        let error = handler
+            .get_transaction_hashes_by_reference(args())
+            .unwrap_err();
+        transition.join().unwrap();
+
+        assert_eq!(error.message(), "reference index is behind");
+        assert_eq!(phase.phase(), ReferenceIndexPhase::Deferred);
+        assert_eq!(*outcomes.lock().unwrap(), [false]);
+    }
+
+    #[test]
+    fn provider_failure_after_wait_is_observed_without_a_timeout() {
+        let indexed_hash = B256::repeat_byte(0x11);
+        let head_hash = B256::repeat_byte(0x22);
+        let missing_header_hash = B256::repeat_byte(0x33);
+        let (_dir, handle) = synced_handle(0, 100, indexed_hash);
+        let provider = TestProvider::new(
+            [
+                ChainInfo {
+                    best_hash: head_hash,
+                    best_number: 1,
+                },
+                ChainInfo {
+                    best_hash: missing_header_hash,
+                    best_number: 2,
+                },
+            ],
+            BTreeMap::from([(head_hash, header(1, 101))]),
+        );
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let observed_outcomes = outcomes.clone();
+        let handler = MorphRpcHandler::new(MorphRpc::new(handle, provider)).with_wait_observer(
+            move |timed_out| {
+                observed_outcomes.lock().unwrap().push(timed_out);
+            },
+        );
+
+        let error = handler
+            .get_transaction_hashes_by_reference(args())
+            .unwrap_err();
+
+        assert_eq!(error.message(), "reference index is behind");
+        assert_eq!(*outcomes.lock().unwrap(), [false]);
     }
 
     #[test]

--- a/crates/rpc/src/morph/rpc.rs
+++ b/crates/rpc/src/morph/rpc.rs
@@ -32,11 +32,14 @@ pub trait MorphRpc {
     /// Returns `-32000 "reference index initializing"` while the runtime is
     /// opening the index.
     ///
-    /// Returns `-32000 "reference index is behind"` unless the durable index
-    /// cursor exactly matches the canonical head number and hash.
+    /// When the durable index cursor lags the canonical head, waits for up to
+    /// 100 ms for the index to catch up. Returns `-32000 "reference index is
+    /// behind"` if the cursor still does not exactly match the canonical head
+    /// number and hash, or while indexing is intentionally deferred.
     ///
-    /// Returns `-32000 "reference index is unavailable"` while the runtime is
-    /// repairing the index or after a non-recoverable index error.
+    /// Returns `-32000 "reference index is unavailable"` only after a
+    /// non-recoverable index error makes the runtime unavailable. A repair in
+    /// progress is reported as `"reference index is behind"`.
     ///
     /// Marked `blocking` because the handler runs synchronous MDBX reads.
     #[method(name = "getTransactionHashesByReference", blocking)]


### PR DESCRIPTION
Stacked on top of #141 (base branch `codex/reth-main-reference-index`); GitHub will retarget this to `main` once #141 merges. Three independent reference-index optimizations, one commit each.

### #145 — simplify reader read gate (`1bc23b4`)
Drops machinery that was not load-bearing for correctness. Read correctness already comes from (1) the MDBX MVCC read-transaction snapshot, (2) the `(indexed_to, indexed_hash) == tip` comparison, and (3) the RPC-layer before/after `chain_info()` bracketing.
- Delete the `generation` seqlock (spin-for-even loop + over-conservative end-of-read re-check).
- Take `phase` out of the read path — it stays a pure metrics/log field; the only remaining read gate is a single `unavailable: AtomicBool`.
- Move the pre-Jade check to the RPC layer via `is_pre_jade` (pre-Jade is a terminal empty answer, not `IndexBehind`).

Closes #145.

### #144 — bounded server-side wait on `IndexBehind` (`c7dfc53`)
The index runtime is asynchronous (#141), so for a few ms after a new block becomes the canonical tip the cursor lags it, and the common "submit a MorphTx then immediately query its reference" pattern hits `IndexBehind` and retries.
- The `blocking` RPC handler now waits a bounded amount (default 100 ms, 5 ms poll) for the runtime to catch up, re-reading the tip each poll, then serves real data.
- Fails fast (no wait) for `Deferred` (rapid sync) and `PreJade` (one-time Jade-activation boundary).
- Adds `rpc_waits_total`, `rpc_wait_timeouts_total`, `rpc_wait_duration_seconds` metrics.

Closes #144.

### #143 — bound reorg rewind floor to the L1 finalized block (`c9f48fe`)
The `IndexedBlocks` breadcrumb table grew linearly and unbounded because the reorg rewind floor was `jade_first`. A fixed depth cap is the wrong fix (any pre-finalized block can reorg; depth depends on block time and L1 batch interval). The true hard boundary is the L1 finalized block.
- `reconcile_cursor` floors the rewind at `max(finalized, jade_first)` (falls back to `jade_first` when finality is unknown).
- `commit_canonical_batch` prunes `IndexedBlocks` breadcrumbs below finalized, only once the cursor tip has reached the floor (deep sub-finalized backfill keeps its rows). Query data is never touched.
- `CanonicalChain` gains `finalized_block_number`, forwarding to `BlockIdReader::finalized_block_number`.

Closes #143.

### Testing
- `cargo test -p morph-reference-index --lib`: 38 passed
- `cargo test -p morph-rpc --lib`: 84 passed
- `cargo clippy -p morph-reference-index -p morph-rpc --lib --tests`: clean

(The crate's doctest target fails for a pre-existing, security-related reason unrelated to this change; verified via `--lib`.)
