### PR TITLE
fix(reference-index): keep transient sync failures retryable

### DIFF
--- a/crates/reference-index/src/runtime.rs
+++ b/crates/reference-index/src/runtime.rs
@@ -224,9 +224,15 @@ impl<C: CanonicalChain> ReferenceIndexRuntime<C> {
     /// Perform one synchronous reconciliation/backfill turn.
     pub fn synchronize_once(&mut self, defer: bool) -> Result<(), ReferenceIndexError> {
         let result = self.synchronize_once_inner(defer);
-        if result.is_err() {
+        if let Err(error) = &result {
             self.handle.metrics().failures_total.increment(1);
-            self.handle.set_phase(ReferenceIndexPhase::Unavailable);
+            // Only unrecoverable failures gate the read path. `run` retries every
+            // other error with backoff, so leaving the phase untouched lets the
+            // cursor-vs-tip comparison surface `IndexBehind` — which tells clients
+            // to retry — instead of `IndexUnavailable`, which tells them to stop.
+            if error.requires_manual_rebuild() {
+                self.handle.set_phase(ReferenceIndexPhase::Unavailable);
+            }
         }
         result
     }
@@ -822,8 +828,29 @@ mod tests {
         let error = runtime.synchronize_once(false).unwrap_err();
 
         assert!(error.to_string().contains("returned 9 of 10 blocks"));
-        assert_eq!(handle.phase(), ReferenceIndexPhase::Unavailable);
+        // A short provider batch is transient: `run` retries it with backoff, so
+        // the phase must stay where the turn left it rather than latch to
+        // `Unavailable`, which would gate the read path for the whole window.
+        assert_eq!(handle.phase(), ReferenceIndexPhase::Backfill);
         assert_eq!(handle.db().unwrap().indexed_to().unwrap(), None);
+    }
+
+    #[test]
+    fn transient_failure_leaves_queries_retryable() {
+        let dir = tempfile::tempdir().unwrap();
+        let chain = ShortRangeChain(TestChain::linear(10, 200));
+        let config = ReferenceIndexConfig::new(dir.path(), 2818, B256::ZERO, 200);
+        let (mut runtime, handle) = ReferenceIndexRuntime::new(config, chain.clone());
+
+        runtime.synchronize_once(false).unwrap_err();
+
+        // The read path must answer `IndexBehind` (retry) and not
+        // `IndexUnavailable` (stop retrying) while catch-up is still pending.
+        let query = crate::ReferenceQuery::new(B256::ZERO, None, None).unwrap();
+        assert!(matches!(
+            handle.query_at(query, chain.0.head().unwrap()),
+            Err(ReferenceIndexError::IndexBehind)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`synchronize_once` latched the runtime phase to `Unavailable` on **every** error:

```rust
if result.is_err() {
    self.handle.metrics().failures_total.increment(1);
    self.handle.set_phase(ReferenceIndexPhase::Unavailable);
}
```

Meanwhile `run` (`runtime.rs:393-403`) classifies errors with
`requires_manual_rebuild()` and retries everything else with exponential backoff
(1s up to 30s). The two sites used **different criteria for the same question**,
so a transient failure — a provider read error, a short canonical batch, an MDBX
hiccup — gated the read path even though catch-up was still in progress and
would succeed on the next turn.

The read path makes this visible: `query_at` short-circuits on `Unavailable`
(`reader.rs:157`) *before* any cursor comparison. During the backoff window,
queries therefore returned `IndexUnavailable` — which tells clients to stop
retrying — even when the durable cursor already matched the canonical tip and
the answer was fully servable. The RPC handler compounds it: `IndexUnavailable`
takes the `Err(other) => return` path (`handler.rs:237`) and so bypasses the
bounded server-side catch-up wait that `IndexBehind` is granted.

## Fix

Gate the phase on the same predicate `run` already uses, so only unrecoverable
errors reach `Unavailable`:

- `CorruptMetadata`
- `ChainIdentityMismatch`
- `SchemaMismatch`
- `ManualRebuildRequired`

Transient errors leave the phase where the turn left it, letting the
cursor-vs-tip comparison surface `IndexBehind` — the retryable signal — on its
own.

Leaving the phase untouched is safe on every path: stopped at `Live` with a
matching cursor the data is genuinely valid and serves; a lagging cursor yields
`IndexBehind`; a first-time `open_db` failure keeps `Opening` with no installed
DB, which yields `Initializing`.

The `Unavailable` set in `run` when the blocking task dies unexpectedly
(`runtime.rs:370`) is unchanged — that path returns without further retries, so
the gate is correct there.

## Impact

No correctness change. The index never served stale rows in either case, and
`Unavailable` was already non-sticky (`set_phase` clears the `unavailable` flag
on the next successful turn). This only removes a false-negative window where a
servable index refused queries and told clients not to come back.

## Tests

- `incomplete_provider_batch_does_not_advance_the_cursor` — updated to assert the
  phase is not polluted to `Unavailable` by a transient short batch; the cursor
  assertion is unchanged.
- `transient_failure_leaves_queries_retryable` — new; asserts the read path
  answers `IndexBehind` rather than `IndexUnavailable` after a transient failure.
- `reorg_reaching_below_finalized_is_bounded_to_a_manual_rebuild` and
  `reorg_without_a_post_jade_ancestor_requires_a_manual_rebuild` — unchanged, and
  now serve as regression protection for the unrecoverable branch.

```
cargo nextest run -p morph-reference-index   # 40 passed
cargo fmt --all -- --check                   # clean
cargo clippy -p morph-reference-index --all-targets -- -D warnings   # clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index availability during temporary synchronization failures.
  * Queries now report that the index is behind when updates are delayed, rather than incorrectly marking it unavailable.
  * Indexes are marked unavailable only when recovery requires a manual rebuild.
  * Incomplete provider batches now remain in the backfill phase for retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->