### PR TITLE
fix(docker): run published images on Ubuntu 24.04 to match cross glibc

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build-push:
     name: Build and Push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -47,6 +47,23 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      # Load a single-arch image and exec `--version` before publishing.
+      # Catches glibc mismatches between the cross builder and Dockerfile.cross
+      # (https://github.com/morph-l2/morph-reth/issues/151).
+      - name: Build amd64 image for smoke test
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.cross
+          load: true
+          push: false
+          platforms: linux/amd64
+          tags: morph-reth:ci-smoke
+          provenance: false
+
+      - name: Smoke test image
+        run: docker run --rm morph-reth:ci-smoke --version
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,13 +1,16 @@
 [build.env]
 passthrough = ["JEMALLOC_SYS_WITH_LG_PAGE"]
 
-# The default x86_64-unknown-linux-gnu cross image (Ubuntu 20.04) ships GCC 9.x,
-# which is affected by https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189 (a memcmp
-# miscompilation). aws-lc-sys >= 0.33 hard-panics with "### COMPILER BUG DETECTED ###"
-# when it finds this compiler, breaking the build. Install GCC 10 (10.3.0, in the
-# "known to work" set) and point gcc/g++/cc at it so every C dependency builds with it.
-# aarch64 is unaffected: it's a true cross-compile, so aws-lc-sys can't run its probe
-# binary and skips the check entirely.
+# Default linux-gnu cross-rs `:main` images are Ubuntu 24.04 (noble, glibc
+# 2.39). Dockerfile.cross must stay on the same Ubuntu series so published
+# images can load the binary.
+#
+# Keep GCC 10 on x86_64: aws-lc-sys >= 0.33 hard-panics with
+# "### COMPILER BUG DETECTED ###" on GCC 9 (Ubuntu 20.04 default) due to
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189. v1.1.0 still ran this
+# pin after the builder moved to noble; leaving it avoids mixing a compiler
+# change into the glibc runtime fix. aarch64 is a true cross-compile, so
+# aws-lc-sys skips the probe.
 [target.x86_64-unknown-linux-gnu]
 pre-build = [
     "apt-get update && apt-get install --assume-yes gcc-10 g++-10",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.95-trixie AS chef
 WORKDIR /app
 
 # reth-mdbx-sys requires libclang for bindgen
@@ -53,8 +53,9 @@ RUN if [ -z "$RUSTFLAGS" ] && [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
 # Copy binary to a fixed location (ARG not resolved in COPY)
 RUN cp /app/target/$BUILD_PROFILE/morph-reth /app/morph-reth
 
-# Minimal runtime image
-FROM debian:bookworm-slim AS runtime
+# Runtime must provide glibc >= the builder (Debian Trixie / Ubuntu 24.04).
+# Matches upstream reth's `ubuntu:24.04` runtime stage.
+FROM ubuntu:24.04 AS runtime
 
 LABEL org.opencontainers.image.source=https://github.com/morph-l2/morph-reth
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,6 +1,11 @@
 # Cross-compilation image: assumes the morph-reth binary has already been
 # compiled for $TARGETPLATFORM and placed in ./dist/bin/$TARGETARCH/
-FROM --platform=$TARGETPLATFORM ubuntu:22.04
+#
+# Runtime Ubuntu must be at least as new as the cross-rs linux-gnu builder
+# (currently Ubuntu 24.04 / glibc 2.39). Shipping 22.04 with a 24.04-built
+# binary fails at start with `GLIBC_2.38/2.39 not found`. Matches upstream
+# reth's `ubuntu:24.04` runtime.
+FROM --platform=$TARGETPLATFORM ubuntu:24.04
 
 LABEL org.opencontainers.image.source=https://github.com/morph-l2/morph-reth
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Published images (`Dockerfile.cross`) now use Ubuntu 24.04 so they match the glibc of the current cross-rs `:main` builder (2.39). This is the same runtime baseline as upstream reth.
- Align the local multi-stage `Dockerfile` (pin `cargo-chef` to rust 1.95/trixie, runtime Ubuntu 24.04) so compose builds do not hit the same class of mismatch.
- Add a CI smoke step that `docker run --rm … --version`s an amd64 image **before** pushing, which would have caught #151.

Fixes #151

## Test plan
- [x] `docker run --rm --platform linux/arm64 ghcr.io/morph-l2/morph-reth:v1.1.0 --version` reproduces `GLIBC_2.38/2.39 not found`
- [x] Same v1.1.0 arm64 binary fails on `ubuntu:22.04`, succeeds on `ubuntu:24.04`
- [x] Pack that binary with the updated `Dockerfile.cross` and `docker run --rm morph-reth:issue-151 --version` prints `Morph-Reth Version: 1.1.0` on Ubuntu 24.04.4
- [ ] Tag/workflow Docker job smoke test passes on the next image build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated container images and build environments to newer Ubuntu and Rust base versions.
  - Improved cross-platform container compatibility, including x86_64 and ARM64 builds.
  - Added compatibility documentation for supported build environments.

- **Validation**
  - Added an automated startup smoke test to verify generated container images run successfully before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->