### PR TITLE
fix(docker): keep git metadata in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
 target/
-.git/
+# NOTE: .git is intentionally NOT excluded. vergen-git2 (crates/node/build.rs)
+# discovers it at build time to embed the commit SHA / describe into the binary
+# version. Excluding it makes those VERGEN_GIT_* + readback env vars unset and the
+# build fails with `Error: NotPresent`. This matches upstream reth's `!/.git`.
 .github/
 .claude/
 .worktrees/


### PR DESCRIPTION
## Summary

- stop excluding .git from the Docker build context
- allow vergen-git2 in crates/node/build.rs to discover repository metadata
- preserve the real commit SHA and version metadata in Docker-built binaries

Without .git, VERGEN_GIT_SHA and related variables are absent and the Docker build fails with Error: NotPresent.

## Validation

- reproduced the failure with a minimal Docker context probe: COPY .git was rejected by .dockerignore
- verified the probe passes after the change
- built the real builder image with Docker on linux/arm64 using the profiling profile
- ran morph-reth --version in the image and verified its commit SHA matches the branch commit
- cargo fmt --all -- --check
- cargo test --all --locked

This PR is intentionally limited to the Docker metadata fix and contains no issue #152 diagnostic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to retain Git metadata during container builds.
  * Added documentation explaining that Git information is used to include version details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->