### PR TITLE
ci(release): drop the build cache to close cache-poisoning alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,12 +101,12 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          key: ${{ matrix.target }}
-
+      # No build cache here on purpose. This job checks out a ref that a
+      # workflow_dispatch caller supplies, and dispatch runs hold write access to
+      # the default-branch cache scope, so caching would let an arbitrary ref
+      # poison the cache that privileged workflows later restore. Upstream reth's
+      # release workflow caches nothing for the same reason; releases are rare
+      # enough that the cold build is worth the isolation.
       - name: Install cross main
         run: cargo install cross --git https://github.com/cross-rs/cross
 


### PR DESCRIPTION
Closes the three open high-severity code-scanning alerts (`actions/cache-poisoning/poisonable-step`, #46/#47/#48) in `.github/workflows/release.yml`.

## Why the alerts fire

| Alert | Line | Step |
|---|---|---|
| #46 | 68 | `Verify Cargo.toml version matches tag` (`cargo metadata`) |
| #47 | 110 | `Install cross main` (`cargo install cross --git`) |
| #48 | 135 | `Build binary` (`make build-*`) |

The workflow takes a `tag` input on `workflow_dispatch` and feeds it to `actions/checkout` as `needs.extract-version.outputs.ref`. Dispatch runs hold **write** access to the default-branch cache scope, so an arbitrary ref could be built and its output written into a cache entry that privileged workflows later restore.

The untrusted checkout is the *source*; the cache is the *sink*. This PR removes the sink.

## Why remove the cache rather than the dispatch input

Three reasons point the same way:

1. It is CodeQL's own first recommendation: *"Avoid using caching in workflows that handle sensitive operations like releases."*
2. **Upstream reth does exactly this.** Its release workflow uses the same untrusted-ref pattern —
   ```yaml
   env:
     RELEASE_REF: ${{ inputs.ref || github.ref }}
   ...
   - uses: actions/checkout@3d3c42e... # v7.0.1
     with:
       ref: ${{ env.RELEASE_REF }}
   ```
   — and caches nothing, which is why the alert does not apply to them.
3. No capability is lost. `workflow_dispatch`, `dry_run` and `profile` all stay.

Removing `workflow_dispatch` instead would also clear the alerts but would drop the manual dry-run and `maxperf` reference-build path.

## Cost

A cold build per release. Releases are infrequent — ten runs over the past five months, all tag pushes — so the isolation is worth more than the build time.

## Other workflows are not affected

- `test.yml`, `lint.yml`, `build.yml`: `pull_request` / `push: [main]`, and they check out `github.ref`. PR runs are scoped to the PR branch cache.
- `docker.yml`: its `workflow_dispatch` takes no inputs and its checkout has no `ref:` override.

None of them combine an untrusted ref with a cache, which matches code scanning flagging only `release.yml`.

## Verification

The CodeQL run on this PR should show all three alerts resolved. If #46 persists — it sits in `check-version`, which has no cache step of its own — that one can be dismissed separately with the same reasoning.

## Follow-up, not in this PR

Upstream also pins actions by SHA and declares workflow-level `permissions: {}` with explicit per-job grants. Worth doing, but out of scope here.

Dependency advisories are handled separately in #166.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release build process to run without the Rust build-artifact cache.
  * Added documentation clarifying the intentional cache isolation for release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->