### PR TITLE
chore: prepare v1.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,7 +5003,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "morph-chainspec"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5026,7 +5026,7 @@ dependencies = [
 
 [[package]]
 name = "morph-consensus"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "morph-engine-api"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "morph-evm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -5100,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "morph-node"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "morph-payload-builder"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "morph-payload-types"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "morph-primitives"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "morph-reference-index"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "morph-reth"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "morph-revm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "morph-rpc"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "morph-statetest"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "morph-txpool"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the workspace and all Morph crates from v1.1.0 to v1.2.0
- refresh `Cargo.lock` for the release version

Release scope (11 commits since `v1.1.0`) includes a sequencer gasLimit ramp feature and a raised per-block DA packing cap, so this is a minor bump.

## Validation
- `cargo check --workspace`
- lockfile diff contains version bumps only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->